### PR TITLE
updating directory names

### DIFF
--- a/docs/AMET_QuickStart_Guide_v14b.md
+++ b/docs/AMET_QuickStart_Guide_v14b.md
@@ -95,12 +95,13 @@ In the AMET **src** directory there are three Fortran programs for pairing model
 * **sitecmp** - pairs hourly and daily observation and model data for many of the networks compatible with AMET
 * **sitecmp_dailyo3** - calculates daily maximum 1-hour and 8-hour ozone pairs for analysis with AMET
 
-To compile these programs, edit the **config.amet** file that is located in the **src** directory.  Point this script to the location of the local I/O API (IOAPI_DR) and netCDF (NETCDF_DIR) installation directories.  Use the following command to apply the settings in the config.amet script before running `make` to build the Tier 3 programs.
+To compile these programs: Set the AMETBASE environment variable to your install directory. Edit the **config.amet** file that is located in the **src** directory. Point this script to the location of the local I/O API (IOAPI_DR) and netCDF (NETCDF_DIR) installation directories.  Use the following command to apply the settings in the config.amet script before running `make` to build the Tier 3 programs.
 
 ```
-cd $AMETBASE/src
+setenv AMETBASE /your_install_path/AMET_v14b
+cd $AMETBASE/tools_src
 source config.amet
-cd bldoverlay; make
+cd bldoverlay/src; make
 cd ../sitecmp; make
 cd ../sitecmp_dailyo3; make
 ```


### PR DESCRIPTION
Hi Wyat,

It looks like the directory names have changed in the latest updates, and also the Makefiles are missing.

In the older version of AMET/v1.4b that I tried earlier

/proj/ie/proj/CMAS/AMET/AMET_v14b_Feb_2019

[lizadams@longleaf-login1 AMET_v14b_Feb_2019]$ find . -name Makefile
./src/sitecmp_dailyo3/Makefile
./src/sitecmp/Makefile
./src/bldoverlay/Makefile

The current version doesn't contain any Makefiles.
ls tools_src/bldoverlay/src
bldoverlay.F  getTZ.F  module_sites.F  parser.F

ls tools_src/sitecmp/src
ck_ctms.F      get_units.F      module_file.F  module_sites.F  module_tstep.F  process.F
get_gridval.F  module_envvar.F  module_grid.F  module_spec.F   parser.F        sitecmp.F

 ls tools_src/sitecmp_dailyo3/src
ck_ctms.F    module_envvar.F  module_grid.F   module_spec.F   parser.F   sitecmp_dailyo3.F
get_units.F  module_file.F    module_sites.F  module_tstep.F  process.F  utilities.F


Liz