### PR TITLE
metExample updates (scripts_db)

### DIFF
--- a/scripts_db/metExample_mcip/loop_over_days.csh
+++ b/scripts_db/metExample_mcip/loop_over_days.csh
@@ -1,22 +1,4 @@
 #! /bin/csh 
-
-#SBATCH -J AMET_Testing
-#SBATCH --export=NONE
-#SBATCH -p singlepe
-#SBATCH -t 01:00:00
-#SBATCH -n 1
-
-#############################################################
-# System config setttings ** No need to change **
-limit stacksize unlimited
-limit memorylocked unlimited
-limit vmemoryuse unlimited
-limit coredumpsize unlimited
-cat $0
-date
-uname -a
-#############################################################
-
 #############################################################
 # Main run config setttings: date start/end, WRF exe, RunID,
 #                            relevant dirs

--- a/scripts_db/metExample_mcip/loop_over_days.csh
+++ b/scripts_db/metExample_mcip/loop_over_days.csh
@@ -1,0 +1,68 @@
+#! /bin/csh 
+
+#SBATCH -J AMET_Testing
+#SBATCH --export=NONE
+#SBATCH -p singlepe
+#SBATCH -t 01:00:00
+#SBATCH -n 1
+
+#############################################################
+# System config setttings ** No need to change **
+limit stacksize unlimited
+limit memorylocked unlimited
+limit vmemoryuse unlimited
+limit coredumpsize unlimited
+cat $0
+date
+uname -a
+#############################################################
+
+#############################################################
+# Main run config setttings: date start/end, WRF exe, RunID,
+#                            relevant dirs
+set begday       = 20201018
+set endday       = 20201029
+
+setenv METTMPDIRX /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/TMP
+
+#############################################################
+set sfcscript   = /home/grc/AMET_v13/scripts_db/mcip_12us1/matching_surface.csh
+set bsrnscript   = /home/grc/AMET_v13/scripts_db/mcip_12us1/matching_bsrn.csh
+set raobscript   = /home/grc/AMET_v13/scripts_db/mcip_12us1/matching_raob.csh
+#############################################################
+
+
+set year  = `echo begday |cut -b1-4`
+set date = $begday
+echo $begday
+#-- Main LOOP Over Days defined above.
+while ( $date <= $endday )
+
+  setenv YYYYS `echo $date |cut -b1-4`
+  setenv YYS   `echo $date |cut -b3-4`
+  setenv MMS   `echo $date |cut -b5-6`
+  setenv DDS   `echo $date |cut -b7-8`
+
+  setenv GRIDCROX /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/GRIDCRO2D
+  setenv METCRO2DX  /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/METCRO2D_${date}.nc4
+  setenv METCRO3DX  /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/METCRO3D_${date}.nc4
+  setenv METDOT3DX  /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/METDOT3D_${date}.nc4
+
+  echo $date
+
+  echo "Running AMET radiation matching"
+   $bsrnscript
+  echo "Running AMET surface matching"
+   $sfcscript
+  echo "Running AMET raob matching"
+   $raobscript
+  
+ ###########################################################
+ # Advance day +1
+ set date = `date -d "$date 1 days" '+%Y%m%d' `
+
+end
+
+exit(1)
+####################################################################
+

--- a/scripts_db/metExample_mcip/matching_bsrn.csh
+++ b/scripts_db/metExample_mcip/matching_bsrn.csh
@@ -22,22 +22,27 @@ setenv MADISBASE $AMETBASE/obs/MET
 # that store all model-observation pairs of data for access by analysis scripts.
 # NEW PROJECTS are automatically created in the database if not existing.
 # RUN_DESCRIPTION: Short description of the model run to keep track its details.
-setenv AMET_PROJECT    metExample_wrf 
-setenv RUN_DESCRIPTION "WRF release test dataset."
+setenv AMET_PROJECT    metExample_mcip 
+setenv RUN_DESCRIPTION "MCIP test dataset."
 
 # Is this a model forecast where intial date/time and forecast hour should be tracked?
 setenv FORECAST F
 
-# Meteorological model output file location and control. The files that can be listed with
-# location below. A wildcard (*) is added in the script to get list of outputs.
-setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/wrfout_subset
+# Meteorological model output file location and control.
+# MCIP output requires slightly different controls as mutiple files for each
+# batch (e.g., daily MCIP) of MCIP are needed. GRIDCRO2D and METCRO2D needed for surface.
+# Users can point METOUTPUT to METCRO2D files and script will match all instances in the
+# defined MCIP directory just like WRF output. But one GRIDCRO2D file needs to be in the 
+# same directory. AMET will look for a GRIDCRO2D file name GRIDCRO2D for grid information only,
+# no time information, so a single file is used for all METCRO2D files.
+ setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/METCRO2D
 
-# Radiation dataset to match with MPAS or WRF
+# Radiation dataset to match with MPAS, WRF or MCIP
 # Options:bsrn or text for non-BSRN obs input
 # Note: user must have these files downloaded MADISBASE/bsrn directory.
 setenv RADIATION_DSET bsrn 
 
-# Interpolation Method for WRF Model: 1 - Nearest Neighbor, 2 - Bi-Linear
+# Interpolation Method for WRF/MCIP Model: 1 - Nearest Neighbor, 2 - Bi-Linear
 # For MPAS, a built in barycentric interpolation is the only option, so this setting
 # does not apply.
 setenv INTERP_METHOD 2

--- a/scripts_db/metExample_mcip/matching_raob.csh
+++ b/scripts_db/metExample_mcip/matching_raob.csh
@@ -1,6 +1,5 @@
 #!/bin/csh
 ####################################################################################
-####################################################################################
 #                          USER CONFIGURATION
 
 # Main AMET directory location. Can be defined explicity here or in user setenv for universal use.
@@ -12,9 +11,9 @@ setenv AMET_DATABASE user_database
 setenv MYSQL_SERVER  mysql.server.gov
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
 
-# Root directory of BSRN obs (same as MADIS). Note that this directory should
-# contain a subdirectory "bsrn" where this radiation obs dataset (unzipped)
-# BSRN directory configuration: $MADISBASE/bsrn 
+# Root directory of MADIS NetCDF obs. Note that this directory should
+# contain subdirectories like this in the standard
+# MADIS directory configuration: $AMETBASE/point/metar/netcdf
 setenv MADISBASE $AMETBASE/obs/MET
 
 # A unique AMETPROJECT name for the simulation to evaluated. 
@@ -22,29 +21,36 @@ setenv MADISBASE $AMETBASE/obs/MET
 # that store all model-observation pairs of data for access by analysis scripts.
 # NEW PROJECTS are automatically created in the database if not existing.
 # RUN_DESCRIPTION: Short description of the model run to keep track its details.
-setenv AMET_PROJECT    metExample_wrf 
-setenv RUN_DESCRIPTION "WRF release test dataset."
+setenv AMET_PROJECT    metExample_mcip 
+setenv RUN_DESCRIPTION "MCIP release test dataset."
 
 # Is this a model forecast where intial date/time and forecast hour should be tracked?
 setenv FORECAST F
 
-# Meteorological model output file location and control. The files that can be listed with
-# location below. A wildcard (*) is added in the script to get list of outputs.
-setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/wrfout_subset
+# Meteorological model output file location and control. 
+# MCIP output requires slightly different controls as mutiple files for each
+# batch (e.g., daily MCIP) of MCIP are needed. GRIDCRO2D, METCRO3D and METDOT3D files.
+# The AMET script looks for generic file names for each of these files in an effort to
+# reduce more significant mods to existing functions. Below is one example.
+# A temporary directory is created. The MCIP files are linked into this temp directory
+# using these generic names using extra RAOB specific scripting towards the end of this
+# csh wrapper. This works for one set of MCIP. If one has mutiple sets of MCIP a wrapper
+# looping script is provided as an example in this same directory where you can loop over
+# days for example and pass those specs into this script and run within this loop.
+setenv METTMPDIR $AMETBASE/model_data/MET/$AMET_PROJECT/TMP
+setenv GRIDCRO   $AMETBASE/model_data/MET/$AMET_PROJECT/GRIDCRO2D_20160701.nc4
+setenv METCRO    $AMETBASE/model_data/MET/$AMET_PROJECT/METCRO3D_20160701.nc4
+setenv METDOT    $AMETBASE/model_data/MET/$AMET_PROJECT/METDOT3D_20160701.nc4
 
-# Radiation dataset to match with MPAS or WRF
-# Options:bsrn or text for non-BSRN obs input
-# Note: user must have these files downloaded MADISBASE/bsrn directory.
-setenv RADIATION_DSET bsrn 
-
-# Interpolation Method for WRF Model: 1 - Nearest Neighbor, 2 - Bi-Linear
-# For MPAS, a built in barycentric interpolation is the only option, so this setting
-# does not apply.
-setenv INTERP_METHOD 2
-
-# Time +/- window averaging of 1 min solar radiation BSRN measurments. 5 would be +/-
-# 5 min (11 min average) from the closest observation to model time.
-setenv OBS_AVG_WINDOW_MIN 5
+# Matching Mode options.
+# Native level matching   : Store full Rawindsonde profile and model profile on their native levels.
+# Mandatory level matching: Interoplate model to ~22 standard pressure levels of the Rawindsonde.
+# Native level matching is more time consuming and will not allow direct statistics since the model
+# and obs are on different levels. This is more for plotting.
+# Mandantory level matching is quick and allows spatial statistics at a specific level or layer over a 
+# defined period. Also allows statistics and barplots for one or more sites displayed as a profile.
+setenv NATIVE    T
+setenv MANDATORY T
 
 # Skip Index specification. The first number is for the first model output, the second for all following.
 # This index is where AMET skips to in order to jump over an initial time period, or past model
@@ -58,22 +64,15 @@ setenv SKIPIND "1 1"
 # the ability to plot spatial statistics or use any windowing of a domain in statistics specs.
 setenv UPDATE_SITES T 
 
-# This control can dramatically improve speed, especially smaller domains where mesonet sites are matched.
-# It is the max number of model times the site list update is done. Typically all obs sites within the
-# domain exist in the first few hours of MADIS obs files. When, for example, you have a small domain that
-# may have 100 obs sites, it slows down the matching to wade through 25,000 records for any new sites. If
-# one does it only for the first 6 hours to build a site list, the script speeds up considerably because
-# it is the most time consuming part of AMET and that step is bypassed.
-setenv MAX_TIMES_SITE_CHECK 1
-
-# Automatic BSRN Obs FTP Option. This requires log/pass to FTP server where BSRN observations are location.
+# Automatic MADIS Obs FTP Option. This requires the FTP server where MADIS observations are location.
+# Warning cira 2017: MADIS obs access has changed over the years, so it's recommended the users check
+# the servers below to make sure they are still active. Also, make sure the FTP server address contains
+# the path to the archive directory (i.e., ftp://FTPadress/archive).
 # Also, users must have MADIS directory structure in place and MADISBASE pointing to that directory.
-# Current BSRN server is defined below. Note: only observation within the domain are downloaded.
-
+# Two current servers are defined below.
 setenv AUTOFTP T
-setenv BSRN_SERVER ftp://ftp.bsrn.awi.de
-setenv BSRN_LOGIN  bsrnftp
-setenv BSRN_PASS   bsrn1
+setenv MADIS_SERVER ftp://madis-data.cprk.ncep.noaa.gov/archive
+setenv MADIS_SERVER ftp://madis-data.ncep.noaa.gov/archive
 
 # Write hourly site insert statements and reject statement to screen or logfile
 setenv VERBOSE T
@@ -84,7 +83,7 @@ setenv VERBOSE T
 ### when running interactively, or via qsub argument password if queued.
 ### This eliminates plain text file password in amet-config.R file and improves
 ### security.
-### Method 1: ./matching_surface.csh (Will prompt for password) 
+### Method 1: ./matching_surface.csh (Will prompt for password)
 ### Method 2: qsub -v password='mysqlpassword' matching_surface.csh
 if (! "$?password" ) then
    echo "Enter the AMET user password: "
@@ -111,6 +110,18 @@ if (! $?amet_pass ) then
     exit(0)
 endif
 ####################################################################################
+####################################################################################
+# Extra scripting for MCIP RAOB only where R model reading function looks for generic
+# MCIP file names: GRIDCRO2D, METCRO3D and METDOT3D
+# Users will have to write more customized wrappers for large batches of data
+# A bit difficult to do here because naming of files can be quite different.
+mkdir -p ${METTMPDIR}
+rm -f ${METTMPDIR}/*
+ln -sf ${GRIDCRO} ${METTMPDIR}/GRIDCRO2D
+ln -sf ${METCRO}  ${METTMPDIR}/METCRO3D
+ln -sf ${METDOT}  ${METTMPDIR}/METDOT3D
+setenv METOUTPUT ${METTMPDIR}/METCRO3D
+echo ${METOUTPUT}
 
 ####################################################################################
 ####################################################################
@@ -118,7 +129,7 @@ endif
 cd $AMETBASE/scripts_db/$AMET_PROJECT
 echo 'Date/Time START'
 date
-R --no-save --slave --args < $AMETBASE/R_db_code/MET_matching_bsrn.R "$amet_pass"
+ R --no-save --slave --args < $AMETBASE/R_db_code/MET_matching_raob.R "$amet_pass"
 echo 'Date/Time END'
 date
 exit (1)

--- a/scripts_db/metExample_mpas/matching_bsrn.csh
+++ b/scripts_db/metExample_mpas/matching_bsrn.csh
@@ -1,13 +1,12 @@
 #!/bin/csh
 ####################################################################################
-####################################################################################
 #                          USER CONFIGURATION
 
-# Main directories of AMET and MADIS data
-setenv AMETBASE  /home/user/AMET_v13
+# Main AMET directory location. Can be defined explicity here or in user setenv for universal use.
+setenv AMETBASE   /home/user/AMET
 
 # Define Database and Password from argument input
-setenv MYSQL_LOGIN   xxxxxxx
+setenv MYSQL_LOGIN   my_login_id
 setenv AMET_DATABASE user_database
 setenv MYSQL_SERVER  mysql.server.gov
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
@@ -24,6 +23,9 @@ setenv MADISBASE $AMETBASE/obs/MET
 # RUN_DESCRIPTION: Short description of the model run to keep track its details.
 setenv AMET_PROJECT    metExample_mpas 
 setenv RUN_DESCRIPTION "MPAS release test dataset."
+
+# Is this a model forecast where intial date/time and forecast hour should be tracked?
+setenv FORECAST F
 
 # Meteorological model output file location and control. The files that can be listed with
 # location below. A wildcard (*) is added in the script to get list of outputs.

--- a/scripts_db/metExample_mpas/matching_raob.csh
+++ b/scripts_db/metExample_mpas/matching_raob.csh
@@ -2,11 +2,11 @@
 ####################################################################################
 #                          USER CONFIGURATION
 
-# Main directories of AMET and MADIS data
-setenv AMETBASE  /home/user/AMET_v13
+# Main AMET directory location. Can be defined explicity here or in user setenv for universal use.
+setenv AMETBASE   /home/user/AMET
 
 # Define Database and Password from argument input
-setenv MYSQL_LOGIN   xxxxxxx
+setenv MYSQL_LOGIN   my_login_id
 setenv AMET_DATABASE user_database
 setenv MYSQL_SERVER  mysql.server.gov
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
@@ -23,6 +23,9 @@ setenv MADISBASE $AMETBASE/obs/MET
 # RUN_DESCRIPTION: Short description of the model run to keep track its details.
 setenv AMET_PROJECT    metExample_mpas 
 setenv RUN_DESCRIPTION "MPAS release test dataset."
+
+# Is this a model forecast where intial date/time and forecast hour should be tracked?
+setenv FORECAST F
 
 # Meteorological model output file location and control. The files that can be listed with
 # location below. A wildcard (*) is added in the script to get list of outputs.

--- a/scripts_db/metExample_mpas/matching_surface.csh
+++ b/scripts_db/metExample_mpas/matching_surface.csh
@@ -2,11 +2,11 @@
 ####################################################################################
 #                          USER CONFIGURATION
 
-# Main directories of AMET and MADIS data
-setenv AMETBASE  /home/user/AMET_v13
+# Main AMET directory location. Can be defined explicity here or in user setenv for universal use.
+setenv AMETBASE   /home/user/AMET
 
 # Define Database and Password from argument input
-setenv MYSQL_LOGIN   xxxxxxx
+setenv MYSQL_LOGIN   my_login_id
 setenv AMET_DATABASE user_database
 setenv MYSQL_SERVER  mysql.server.gov
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
@@ -23,6 +23,9 @@ setenv MADISBASE $AMETBASE/obs/MET
 # RUN_DESCRIPTION: Short description of the model run to keep track its details.
 setenv AMET_PROJECT    metExample_mpas 
 setenv RUN_DESCRIPTION "MPAS release test dataset."
+
+# Is this a model forecast where intial date/time and forecast hour should be tracked?
+setenv FORECAST F
 
 # Meteorological model output file location and control. The files that can be listed with
 # location below. A wildcard (*) is added in the script to get list of outputs.

--- a/scripts_db/metExample_wrf/matching_raob.csh
+++ b/scripts_db/metExample_wrf/matching_raob.csh
@@ -2,11 +2,11 @@
 ####################################################################################
 #                          USER CONFIGURATION
 
-# Main directories of AMET and MADIS data
-#setenv AMETBASE  /proj/ie/proj/CMAS/AMET/AMET_v14b
+# Main AMET directory location. Can be defined explicity here or in user setenv for universal use.
+setenv AMETBASE   /home/user/AMET
 
 # Define Database and Password from argument input
-setenv MYSQL_LOGIN   xxxxxxx
+setenv MYSQL_LOGIN   my_login_id
 setenv AMET_DATABASE user_database
 setenv MYSQL_SERVER  mysql.server.gov
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
@@ -23,6 +23,9 @@ setenv MADISBASE $AMETBASE/obs/MET
 # RUN_DESCRIPTION: Short description of the model run to keep track its details.
 setenv AMET_PROJECT    metExample_wrf 
 setenv RUN_DESCRIPTION "WRF release test dataset."
+
+# Is this a model forecast where intial date/time and forecast hour should be tracked?
+setenv FORECAST F
 
 # Meteorological model output file location and control. The files that can be listed with
 # location below. A wildcard (*) is added in the script to get list of outputs.

--- a/scripts_db/metExample_wrf/matching_surface.csh
+++ b/scripts_db/metExample_wrf/matching_surface.csh
@@ -2,14 +2,13 @@
 ####################################################################################
 #                          USER CONFIGURATION
 
-# Main directories of AMET and MADIS data
-#setenv AMETBASE  /proj/ie/proj/CMAS/AMET/AMET_v14b
+# Main AMET directory location. Can be defined explicity here or in user setenv for universal use.
+setenv AMETBASE   /home/user/AMET
 
 # Define Database and Password from argument input
-setenv MYSQL_LOGIN   amet
+setenv MYSQL_LOGIN   my_login_id
 setenv AMET_DATABASE user_database
-#setenv MYSQL_SERVER  mysql.server.gov
-setenv MYSQL_SERVER localhost
+setenv MYSQL_SERVER  mysql.server.gov
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
 
 # Root directory of MADIS NetCDF obs. Note that this directory should
@@ -24,6 +23,9 @@ setenv MADISBASE $AMETBASE/obs/MET
 # RUN_DESCRIPTION: Short description of the model run to keep track its details.
 setenv AMET_PROJECT    metExample_wrf 
 setenv RUN_DESCRIPTION "WRF release test dataset."
+
+# Is this a model forecast where intial date/time and forecast hour should be tracked?
+setenv FORECAST F
 
 # Meteorological model output file location and control. The files that can be listed with
 # location below. A wildcard (*) is added in the script to get list of outputs.


### PR DESCRIPTION
- This pull request updates AMET with model-obs matching scripts (scripts_db) for the new MCIP compatibility. In addition to metExample_wrf and metExample_mpas, a metExample_mcip directory with scripts was added. These scripts are different from the WRF and MPAS counterparts in that MCIP has multiple files for each day/period. Some extra stuff was added to AMET matching codes as well as these matching cshell scripts. Details are provided in the comments.
- A loop over days script is provided in the metExample_mcip directory to help users do matching for large batches of data where looping over each day and running single instances of AMET matching is done.
- Existing metExample_mpas and metExample_wrf scripts had a FORECAST flag option. This was added to actual R codes to handle cases where users are running forecast models. This essentially adds forecast hour as an attribute that can be queried against. It is default False, so backward compatible for user's past non-forecast applications. Added for a NOAA user. These raob, bsrn and surface matching scripts had a few minor changes dummy arguments in the templates and comment changes.



