### PR TITLE
Meteorology updates of the R database population, model-obs matching …

### DIFF
--- a/R_db_code/MET_dbase.R
+++ b/R_db_code/MET_dbase.R
@@ -17,6 +17,8 @@
 #        - Added functions for upper-air meteorology. These include table
 #          creation functions for rawindsonde and wind profilers. Also,
 #          functions to write out profile queries to query file connection.
+#  V1.5, 2020Feb21, Robert Gilliam: 
+#        - Fixed level bug in raob_query functions that in some cases produced Inf values. Skips now.
 #
 #######################################################################################################
 #######################################################################################################
@@ -345,7 +347,7 @@
                      level_id,",",varid_str,",",var_str,")")
 
    for(l in 1:nl) {
-    if(is.na(levels[l]) || is.na(profiles[l,1]) || is.na(profiles[l,2]) ) { next }
+    if(is.infinite(levels[l]) || is.na(levels[l]) || is.na(profiles[l,1]) || is.na(profiles[l,2]) ) { next }
     val1<-ifelse(is.na(profiles[l,1]),'NULL',profiles[l,1])
     val2<-ifelse(is.na(profiles[l,2]),'NULL',profiles[l,2])
     values_str<-paste(val1,",",val2,sep="")
@@ -396,6 +398,7 @@
    mod.lrange   <- rev(range(mod[,1],na.rm=T))
    levels       <- ifelse(levels < mod.lrange[2], NA, levels)
    levels       <- ifelse(levels > mod.lrange[1], NA, levels)
+   levels       <- ifelse(is.infinite(levels), NA, levels)
    
    # Interpolate model to obs levels using spline interpolation function
    func        = splinefun(x=mod[,1], y=mod[,2], method="fmm",  ties = mean)

--- a/R_db_code/MET_matching_raob.R
+++ b/R_db_code/MET_matching_raob.R
@@ -23,8 +23,17 @@
 #
 #  V1.4, 2018Sep30, Robert Gilliam: Initial Development
 #
+#  V1.5, 2021Jan07, Robert Gilliam: 
+#         - Added controls for MCIP compatibility. Main updates made in MET_model_read.R.
+#         - MPAS limited area mesh are compatible. Interp weights are NA for sites not in the domain
+#         - Added forecast cycle and forecast hour in the case of forecast model eval.
+#         - Temp text query files pushed to MySQL file naming was changed by adding a random large
+#           number in the name (num between 1-100000). This allows multiple threads at the same time
+#           in the same project directory.
+#
 #######################################################################################################
 #######################################################################################################
+  options(warn=-1)
   if(!require(RMySQL)) {stop("Required Package RMySQL was not loaded") }
   if(!require(date))   {stop("Required Package date was not loaded")   }
   if(!require(ncdf4))  {stop("Required Package ncdf4 was not loaded")  }
@@ -102,13 +111,16 @@
   # mysql server details below has two options with the first commented out. 1) Plain text
   # file with password (not secure) and 2) The default, via csh script and password argument.
   # For option 1, the file is $AMETBASE/configure/amet-config.R 
+  query_file1<-paste("tmp.raob.query.",sample(1:100000,1),sep="")
+  query_file2<-paste("tmp.site.query.",sample(1:100000,1),sep="")
+
   mysql          <-list(server=mysqlserver,dbase=ametdbase,login=mysqllogin,passwd=mysqlpass,maxrec=5E6)
   command        <-paste("mysql --host=",mysql$server," --user=",mysql$login," --password='",
-                          mysql$passwd,"' --database=",mysql$dbase," < tmp.raob.query",sep="")
+                          mysql$passwd,"' --database=",mysql$dbase," < ",query_file1,sep="")
   sitecommand    <-paste("mysql --host=",mysql$server," --user=",mysql$login," --password='",
-                          mysql$passwd,"' --database=",mysql$dbase," < tmp.site.query",sep="")
+                          mysql$passwd,"' --database=",mysql$dbase," < ",query_file2,sep="")
 
-  files <-system(paste("ls -lh ",met_output,"*",sep=''),intern=T)
+  files <-system(paste("ls -Llh ",met_output,"*",sep=''),intern=T)
   nf    <-length(files)
   
   # Skip index setting for first file (1) and all after (2)
@@ -116,6 +128,15 @@
   skipind1 <-as.numeric(unlist(a)[1])
   skipind2 <-as.numeric(unlist(a)[2])
   
+  # Forecast model output? Initialize related vars
+  fcast <- as.logical(Sys.getenv('FORECAST'))
+  if (is.na(fcast) || !fcast) {
+     fcast    <- F
+     init_utc <- -99
+     fcast_hr <- 0
+     dthr     <- 0
+  }
+
   # Site mapping to model grid arrays for MPAS or WRF. Note CIND and CWGT are MPAS index
   # arrays and interp weighting values. WRFIND is the eqivalent for WRF. Values [site,1:3,1:2]
   # are indicies of the four grid point surrounding the obs site. [site,1,1:2] is the first and
@@ -138,16 +159,20 @@ for(f in 1:nf) {
   parts<-unlist(strsplit(files[f], " "))
   file <-parts[length(parts)]
   f1  <-nc_open(file)
-   head    <- ncatt_get(f1, varid=0, attname="TITLE" )$value
-   metmodel<- ncatt_get(f1, varid=0, attname="model_name" )$value
+   wrf.chk  <- ncatt_get(f1, varid=0, attname="TITLE" )$value
+   mpas.chk <- ncatt_get(f1, varid=0, attname="model_name" )$value
+   mcip.chk <- ncatt_get(f1, varid=0, attname="EXEC_ID" )$value
   nc_close(f1)
-  if(metmodel == "mpas") {
+  if(mpas.chk != 0) {
    metmodel<-"mpas"
-   writeLines(paste("Matching MPAS output file with observations:",file))
-  } else if(head != 0) {
+   writeLines(paste("Matching MPAS output file with surface observations:",file))
+  } else if(wrf.chk != 0) {
    metmodel<-"wrf"
-   writeLines(paste("Matching WRF output file with observations:",file))
-  } else if(metmodel == 0 & head == 0){ 
+   writeLines(paste("Matching WRF output file with surface observations:",file))
+  } else if(mcip.chk != 0) {
+   metmodel<-"mcip"
+   writeLines(paste("Matching MCIP METCRO3D/METDOT3D file with surface observations:",file))
+  } else { 
    writeLines("The model output is not standard WRF or MPAS output. Double check. 
                Terminating model-observation matching.")
    quit(save="no")
@@ -179,6 +204,18 @@ for(f in 1:nf) {
     model <-wrf_raob(file,t=1)
   }
 
+  if(metmodel == "mcip"){
+    model <-mcip_raob(file,t=1)
+  }
+
+  # If forecast run, use date/time function to get init time and output interval
+  if (fcast) {
+    init_utc <- model_time_format(model$raob_met$time)$hc
+     dthr    <- as.numeric(model_time_format(model$raob_met$time[2])$hc) -
+                as.numeric(model_time_format(model$raob_met$time[1])$hc)
+    fcast_hr <- 0
+  }
+
 ##########################################################################
 # begin loop for hours in MPAS file (Model values are extracted each time increment)
 if(f == 1) { skipind <- skipind1 }
@@ -194,6 +231,11 @@ for(t in skipind:nt){
   datetime <- model_time_format(model$raob_met$time[t])
   # Limit times to standard soundings (i.e.; 00 and 12 UTC)
   if(datetime$hc != "00" & datetime$hc != "12") { next }
+
+  # Compute forecast hour if applicable
+  if (fcast) {
+    fcast_hr <- (t-1) * dthr
+  }
 
   # Extract obs from MADIS file along with site metadata
   # return variable contains two lists: site and raob_met
@@ -216,6 +258,9 @@ for(t in skipind:nt){
   if(metmodel == "wrf"){
     model <-wrf_raob(file,t=t)
   }
+  if(metmodel == "mcip"){
+    model <-mcip_raob(file,t=t)
+  }
 
   # MAP observation sites to model grid cell and update new sites.
   if(metmodel == "mpas" & total_loop_count <= total_loop_max){
@@ -223,17 +268,18 @@ for(t in skipind:nt){
                                  obs$meta$slon, obs$meta$elev, obs$meta$report_type, obs$meta$site_locname,
                                  model$projection$lat, model$projection$lon, model$projection$latv, 
                                  model$projection$lonv, model$projection$cells_on_vertex,
-                                 cind, cwgt,  mysql$dbase, sitecommand, sitemax, updateSiteTable)
+                                 cind, cwgt,  mysql$dbase, sitecommand, sitemax, updateSiteTable,
+                                 tmpquery_file=query_file2)
     sitenum <-site_update$sitenum
     sitelist<-site_update$sitelist
     cind    <-site_update$cind
     cwgt    <-site_update$cwgt
   }
-  if(metmodel == "wrf" & total_loop_count <= total_loop_max){
+  if((metmodel == "wrf" || metmodel == "mcip") & total_loop_count <= total_loop_max){
     site_update <- wrf_site_map(obs$meta$site, obs$meta$sites_unique, sitelist, sitenum, obs$meta$slat, 
                                 obs$meta$slon, obs$meta$elev, obs$meta$report_type, obs$meta$site_locname, 
                                 model$projection, wrfind, interp, mysql$dbase, sitecommand, sitemax, 
-                                updateSiteTable, buffer=buffer)
+                                updateSiteTable, buffer=buffer, tmpquery_file=query_file2)
     sitenum <-site_update$sitenum
     sitelist<-site_update$sitelist
     wrfind  <-site_update$wrfind
@@ -242,8 +288,8 @@ for(t in skipind:nt){
 writeLines("**********************************************************************************************")
 
 # Open new query file
-system("rm -f tmp.raob.query") 
-sfile<-file("tmp.raob.query","a")
+system(paste("rm -f ",query_file1)) 
+sfile<-file(query_file1,"a")
 writeLines(paste("use",mysql$dbase,";"),con=sfile) 
 ##########################################################################
   # Main Loop over observation sites for a defined date/time of model output
@@ -279,6 +325,7 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
     ###############################################################################################
     # Define model profiles, dependent on model.
     if(metmodel == "mpas"){
+      if(is.na(cwgt[s,1])) { next }
       t_mod     <- model$raob_met$temp[,cind[s,1]]
       rh_mod    <- model$raob_met$rh[,cind[s,1]]
       u_mod     <- model$raob_met$u[,cind[s,1]]
@@ -286,7 +333,7 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
       zlev_mod  <- model$raob_met$levzh[,cind[s,1]]
       plev_mod  <- model$raob_met$p[,cind[s,1]]
     }
-    if(metmodel == "wrf"){
+    if(metmodel == "wrf" || metmodel == "mcip"){
       x         <-wrfind[s,1,1]
       y         <-wrfind[s,2,1]
       t_mod     <- model$raob_met$temp[x,y,]
@@ -306,23 +353,23 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
       profiles   <- data.frame(obs$raob_met$temps[,all.sind],obs$raob_met$rhs[,all.sind])
       levels     <- obs$raob_met$prest[,all.sind]
       raob_query_native(sfile, ametproject, obs$meta$site[all.sind],mysqltimestr, datetime$modeltime,
-                        varid_str, var_str, varid_vals, profiles, levels) 
+                        varid_str, var_str, varid_vals, profiles, levels, fcast_hr=fcast_hr, init_utc=init_utc) 
       varid_vals <-"'T_MOD_N', 'RH_MOD_N'"
       profiles   <- data.frame(t_mod,rh_mod)
       levels     <- plev_mod
       raob_query_native(sfile, ametproject, obs$meta$site[all.sind],mysqltimestr, datetime$modeltime,
-                        varid_str, var_str, varid_vals, profiles, levels) 
+                        varid_str, var_str, varid_vals, profiles, levels, fcast_hr=fcast_hr, init_utc=init_utc) 
       # U and V of obs and model
       varid_vals<-"'U_OBS_N', 'V_OBS_N'"
       profiles  <- data.frame(obs$raob_met$us[,all.sind],obs$raob_met$vs[,all.sind])
       levels    <- obs$raob_met$ghgts[,all.sind]
       raob_query_native(sfile, ametproject, obs$meta$site[all.sind],mysqltimestr, datetime$modeltime,
-                        varid_str, var_str, varid_vals, profiles, levels) 
+                        varid_str, var_str, varid_vals, profiles, levels, fcast_hr=fcast_hr, init_utc=init_utc) 
       varid_vals<-"'U_MOD_N', 'V_MOD_N'"
       profiles  <- data.frame(u_mod,v_mod)
       levels    <- zlev_mod
       raob_query_native(sfile, ametproject, obs$meta$site[all.sind],mysqltimestr, datetime$modeltime,
-                        varid_str, var_str, varid_vals, profiles, levels) 
+                        varid_str, var_str, varid_vals, profiles, levels, fcast_hr=fcast_hr, init_utc=init_utc) 
      } 
      ###############################################################################################
      # Mandatory Pressure level interpolation and query write to main query file connection.
@@ -332,28 +379,28 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
       obsdf   <- data.frame(obs$raob_met$presm[,all.sind], obs$raob_met$tempm[,all.sind])
       moddf   <- data.frame(plev_mod, t_mod)
       raob_query_mandatory(sfile, ametproject, obs$meta$site[all.sind],mysqltimestr, datetime$modeltime,
-                           varid_str, var_str, varid_vals, obsdf, moddf) 
+                           varid_str, var_str, varid_vals, obsdf, moddf, fcast_hr=fcast_hr, init_utc=init_utc) 
 
       # RH 
       varid_vals<-"'RH_OBS_M', 'RH_MOD_M'"
       obsdf   <- data.frame(obs$raob_met$presm[,all.sind], obs$raob_met$rhm[,all.sind])
       moddf   <- data.frame(plev_mod, rh_mod)
       raob_query_mandatory(sfile, ametproject, obs$meta$site[all.sind],mysqltimestr, datetime$modeltime,
-                           varid_str, var_str, varid_vals, obsdf, moddf) 
+                           varid_str, var_str, varid_vals, obsdf, moddf, fcast_hr=fcast_hr, init_utc=init_utc) 
 
      # U 
       varid_vals<-"'U_OBS_M', 'U_MOD_M'"
       obsdf   <- data.frame(obs$raob_met$presm[,all.sind], obs$raob_met$um[,all.sind])
       moddf   <- data.frame(plev_mod, u_mod)
       raob_query_mandatory(sfile, ametproject, obs$meta$site[all.sind],mysqltimestr, datetime$modeltime,
-                           varid_str, var_str, varid_vals, obsdf, moddf) 
+                           varid_str, var_str, varid_vals, obsdf, moddf, fcast_hr=fcast_hr, init_utc=init_utc) 
 
      # V 
       varid_vals<-"'V_OBS_M', 'V_MOD_M'"
       obsdf   <- data.frame(obs$raob_met$presm[,all.sind], obs$raob_met$vm[,all.sind])
       moddf   <- data.frame(plev_mod, v_mod)
       raob_query_mandatory(sfile, ametproject, obs$meta$site[all.sind],mysqltimestr, datetime$modeltime,
-                           varid_str, var_str, varid_vals, obsdf, moddf) 
+                           varid_str, var_str, varid_vals, obsdf, moddf, fcast_hr=fcast_hr, init_utc=init_utc) 
      } 
      ###############################################################################################
 
@@ -370,7 +417,7 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
 
 ##########################################################################
 }  # End of loop over files
-system("rm -f tmp.raob.query") 
-system("rm -f tmp.site.query") 
+system(paste("rm -f ",query_file1)) 
+system(paste("rm -f ",query_file2)) 
 quit(save="no")
 

--- a/R_db_code/MET_matching_surface.R
+++ b/R_db_code/MET_matching_surface.R
@@ -27,7 +27,16 @@
 #         - Added the matching of surface pressure for the ability
 #           to evaluate relative humidity
 #
+#  V1.5, 2020Nov13, Robert Gilliam: 
+#         - Added controls for MCIP compatibility. Main updates made in MET_model_read.R.
+#         - MPAS limited area mesh are compatible. Interp weights are NA for sites not in the domain
+#         - Added forecast cycle and forecast hour in the case of forecast model eval.
+#         - Temp text query files pushed to MySQL file naming was changed by adding a random large
+#           number in the name (num between 1-100000). This allows multiple threads at the same time
+#           in the same project directory.
+#
 #######################################################################################################
+  options(warn=-1)
   if(!require(RMySQL)) {stop("Required Package RMySQL was not loaded") }
   if(!require(date))   {stop("Required Package date was not loaded")   }
   if(!require(ncdf4))  {stop("Required Package ncdf4 was not loaded")  }
@@ -80,14 +89,14 @@
   maxdtmin       <- as.numeric(Sys.getenv("MAXDTMIN"))
   skipind        <- Sys.getenv("SKIPIND")
   interp         <- Sys.getenv("INTERP_METHOD")
-  updateSiteTable<-as.logical(Sys.getenv("UPDATE_SITES"))
+  updateSiteTable<- as.logical(Sys.getenv("UPDATE_SITES"))
   total_loop_max <- as.numeric(Sys.getenv("MAX_TIMES_SITE_CHECK"))
-  autoftp        <-as.logical(Sys.getenv("AUTOFTP"))
+  autoftp        <- as.logical(Sys.getenv("AUTOFTP"))
   madis_server   <- Sys.getenv("MADIS_SERVER")
   verbose        <- as.logical(Sys.getenv("VERBOSE"))
 
-  userid         <-system("echo $USER",intern = TRUE)
-  projectdate    <-as.POSIXlt(Sys.time(), "GMT")
+  userid         <- system("echo $USER",intern = TRUE)
+  projectdate    <- as.POSIXlt(Sys.time(), "GMT")
 
   # MySQL connection information and command to send temporary query file to database.
   # This method is dramatically quicker than sending single queries for each of the
@@ -95,13 +104,16 @@
   # mysql server details below has two options with the first commented out. 1) Plain text
   # file with password (not secure) and 2) The default, via csh script and password argument.
   # For option 1, the file is $AMETBASE/configure/amet-config.R 
+  query_file1<-paste("tmp.sfc.query.",sample(1:100000,1),sep="")
+  query_file2<-paste("tmp.site.query.",sample(1:100000,1),sep="")
+
   mysql          <-list(server=mysqlserver,dbase=ametdbase,login=mysqllogin,passwd=mysqlpass,maxrec=5E6)
   command        <-paste("mysql --host=",mysql$server," --user=",mysql$login," --password='",
-                          mysql$passwd,"' --database=",mysql$dbase," < tmp.query",sep="")
+                          mysql$passwd,"' --database=",mysql$dbase," < ",query_file1,sep="")
   sitecommand    <-paste("mysql --host=",mysql$server," --user=",mysql$login," --password='",
-                          mysql$passwd,"' --database=",mysql$dbase," < tmp.site.query",sep="")
+                          mysql$passwd,"' --database=",mysql$dbase," < ",query_file2,sep="")
 
-  files <-system(paste("ls -lh ",met_output,"*",sep=''),intern=T)
+  files <-system(paste("ls -Llh ",met_output,"*",sep=''),intern=T)
   nf    <-length(files)
 
   # Hard coded settings now
@@ -113,6 +125,15 @@
   skipind1 <-as.numeric(unlist(a)[1])
   skipind2 <-as.numeric(unlist(a)[2])
   
+  # Forecast model output? Initialize related vars
+  fcast <- as.logical(Sys.getenv('FORECAST'))
+  if (is.na(fcast) || !fcast) {
+     fcast    <- F
+     init_utc <- -99
+     fcast_hr <- 0
+     dthr     <- 0
+  }
+
   # Site mapping to model grid arrays for MPAS or WRF. Note CIND and CWGT are MPAS index
   # arrays and interp weighting values. WRFIND is the eqivalent for WRF. Values [site,1:3,1:2]
   # are indicies of the four grid point surrounding the obs site. [site,1,1:2] is the first and
@@ -130,20 +151,24 @@
 # Begin loop over Model Output files
 for(f in 1:nf) {
 
-  # Model output file name from list spec and meteorological model
+  # Model output file names from list spec and met model check.
   parts<-unlist(strsplit(files[f], " "))
   file <-parts[length(parts)]
   f1  <-nc_open(file)
-   head    <- ncatt_get(f1, varid=0, attname="TITLE" )$value
-   metmodel<- ncatt_get(f1, varid=0, attname="model_name" )$value
+   wrf.chk  <- ncatt_get(f1, varid=0, attname="TITLE" )$value
+   mpas.chk <- ncatt_get(f1, varid=0, attname="model_name" )$value
+   mcip.chk <- ncatt_get(f1, varid=0, attname="EXEC_ID" )$value
   nc_close(f1)
-  if(metmodel == "mpas") {
+  if(mpas.chk != 0) {
    metmodel<-"mpas"
-   writeLines(paste("Matching MPAS output file with observations:",file))
-  } else if(head != 0) {
+   writeLines(paste("Matching MPAS output file with surface observations:",file))
+  } else if(wrf.chk != 0) {
    metmodel<-"wrf"
-   writeLines(paste("Matching WRF output file with observations:",file))
-  } else if(metmodel == 0 & head == 0){ 
+   writeLines(paste("Matching WRF output file with surface observations:",file))
+  } else if(mcip.chk != 0) {
+   metmodel<-"mcip"
+   writeLines(paste("Matching MCIP METCRO2D file with surface observations:",file))
+  } else { 
    writeLines("The model output is not standard WRF or MPAS output. Double check. 
                Terminating model-observation matching.")
    quit(save="no")
@@ -173,6 +198,23 @@ for(f in 1:nf) {
     model<-wrf_surface(file)
   }
 
+  # MCIP Grid and Sfc Met extraction
+  #list includes:
+  #projection <-list(mproj=mproj,lat=lat,lon=lon,lat1=lat1,lon1=lon1,nx=nx,ny=ny,
+  #                  dx=dx,truelat1=truelat1,truelat2=truelat2,standlon=standlon,conef=cone)
+  #sfc_met    <-list(time=time,t2=t2,q2=q2,u10=u10,v10=v10,swr=swr,psf=psf)
+  if(metmodel == "mcip"){
+    model<-mcip_surface(file)
+  }
+
+  # If forecast run, use date/time function to get init time and output interval
+  if (fcast) {
+    init_utc <- model_time_format(model$sfc_met$time[1])$hc
+     dthr    <- as.numeric(model_time_format(model$sfc_met$time[2])$hc) -
+                as.numeric(model_time_format(model$sfc_met$time[1])$hc)
+    fcast_hr <- 0
+  }
+
 ##########################################################################
 # begin loop for hours in MPAS file (reads one MADIS file)
 if(f == 1) { skipind <- skipind1 }
@@ -190,7 +232,7 @@ for(t in skipind:nt){
       next 
     }
   }
-  if(metmodel == "wrf"){
+  if(metmodel == "wrf" || metmodel == "mcip"){
     if(sum( model$sfc_met$t2[,,t]) == 0){ 
       writeLines(paste("WRF time period skipped because initial model time"))
       next 
@@ -201,6 +243,11 @@ for(t in skipind:nt){
   # return variable contains one list variable 
   # modeldate, modeltime, yc, mc, dc, hc
   datetime<- model_time_format(model$sfc_met$time[t])
+
+  # Compute forecast hour if applicable
+  if (fcast) {
+    fcast_hr <- (t-1) * dthr
+  }
 
   # Extract obs from MADIS file along with site metadata
   # return variable contains two lists: site and sfc_met
@@ -214,30 +261,33 @@ for(t in skipind:nt){
   } else if(madis_dset == "text") {
     obs<- text_surface(madisbase, datetime, model$projection$standlon, model$projection$conef)
   }
+
   if(metmodel == "mpas" & total_loop_count <= total_loop_max){
     site_update <- mpas_site_map(obs$meta$site, obs$meta$sites_unique, sitelist, sitenum, obs$meta$slat, 
                                  obs$meta$slon, obs$meta$elev, obs$meta$report_type, obs$meta$site_locname,
                                  model$projection$lat, model$projection$lon, model$projection$latv, 
                                  model$projection$lonv, model$projection$cells_on_vertex,
-                                 cind, cwgt,  mysql$dbase, sitecommand, sitemax, updateSiteTable)
+                                 cind, cwgt,  mysql$dbase, sitecommand, sitemax, updateSiteTable,
+                                 tmpquery_file=query_file2)
     sitenum <-site_update$sitenum
     sitelist<-site_update$sitelist
     cind    <-site_update$cind
     cwgt    <-site_update$cwgt
   }
-  if(metmodel == "wrf" & total_loop_count <= total_loop_max){
+  if((metmodel == "wrf" || metmodel == "mcip") & total_loop_count <= total_loop_max){
     site_update <- wrf_site_map(obs$meta$site, obs$meta$sites_unique, sitelist, sitenum, obs$meta$slat, 
                                 obs$meta$slon, obs$meta$elev, obs$meta$report_type, obs$meta$site_locname, 
                                 model$projection, wrfind, interp, mysql$dbase, sitecommand, sitemax, 
-                                updateSiteTable, buffer=buffer)
+                                updateSiteTable, buffer=buffer, tmpquery_file=query_file2)
     sitenum <-site_update$sitenum
     sitelist<-site_update$sitelist
     wrfind  <-site_update$wrfind
   }
+
 writeLines("**********************************************************************************************")
 # Open new query file
-system("rm -f tmp.query") 
-sfile<-file("tmp.query","a")
+system(paste("rm -f ",query_file1)) 
+sfile<-file(query_file1,"a")
 writeLines(paste("use",mysql$dbase,";"),con=sfile) 
 ##########################################################################
   # Main Loop over observation sites for a defined date/time of model output
@@ -277,6 +327,7 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
 
     # Calculate model values base on barycentric interpolation if MPAS
     if(metmodel == "mpas"){
+      if(is.na(cwgt[s,1])) { next }
       t2_int   <-cwgt[s,1]*model$sfc_met$t2[cind[s,1],t]+cwgt[s,2]*model$sfc_met$t2[cind[s,2],t]+
                  cwgt[s,3]*model$sfc_met$t2[cind[s,3],t]
       q2_int   <-cwgt[s,1]*model$sfc_met$q2[cind[s,1],t]+cwgt[s,2]*model$sfc_met$q2[cind[s,2],t]+
@@ -288,7 +339,8 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
       psf_int  <-cwgt[s,1]*model$sfc_met$psf[cind[s,1],t]+cwgt[s,2]*model$sfc_met$psf[cind[s,2],t]+
                  cwgt[s,3]*model$sfc_met$psf[cind[s,3],t]
     }
-    if(metmodel == "wrf"){
+
+    if(metmodel == "wrf" || metmodel == "mcip"){
       # Compute model values from the site-mapped grid idicies. This is a bilinear interpolation
       # calculation using the four grid points surrounding observation site. It is written to
       # work with nearest neighbor where fractional grid index in x and y direction (wrfind[s,3,1:2])
@@ -328,7 +380,7 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
     q1    <-paste("REPLACE INTO ",ametproject,"_surface (proj_code, stat_id, ob_date, ob_time,fcast_hr, init_utc,T_ob,  T_mod,
                    U_ob,  U_mod,  V_ob,  V_mod,  WVMR_ob, Q_ob, Q_mod, PSFC_ob, PSFC_mod)",sep="")
     q2    <-paste("('",ametproject,"','",obs$meta$site[sind],"','",mysqltimestr,"','",
-                  datetime$modeltime,"',0,00,",obs$sfc_met$t2[sind],",",t2_int,",",
+                  datetime$modeltime,"',",fcast_hr,",",init_utc,",",obs$sfc_met$t2[sind],",",t2_int,",",
                   obs$sfc_met$u10[sind],",",u10_int,",",obs$sfc_met$v10[sind],",",v10_int,",",
                   obs$sfc_met$q2[sind],",",obs$sfc_met$q2[sind],",",q2_int,",",
                   obs$sfc_met$psf[sind],",",psf_int,")",sep="")
@@ -348,6 +400,7 @@ writeLines(paste("use",mysql$dbase,";"),con=sfile)
 
 ##########################################################################
 }  # End of loop over files
-system("rm -f tmp.query tmp.site.query") 
+system(paste("rm -f ",query_file1)) 
+system(paste("rm -f ",query_file2)) 
 quit(save="no")
 

--- a/R_db_code/MET_misc.R
+++ b/R_db_code/MET_misc.R
@@ -11,15 +11,46 @@
 #  V1.3, 2017Apr18, Robert Gilliam: Initial Development
 #  V1.4, 2018Sep30, Robert Gilliam: 
 #         - No updates
+#  V1.5, 2020Feb05, Robert Gilliam: Added a function to check if variable exist in NetCDF file
 #
 #######################################################################################################
 #######################################################################################################
 #     This script contains the following functions
 #
-#     test    --> this is a generic function used to test the development of new functions
+#     ncdf_vars_exist   --> Reads variables in NetCDF file and returns logical if var exists or not.
+#     test              --> this is a generic function dummy function to copy and paste for new functs.
 #
 #######################################################################################################
 #######################################################################################################
+##########################################################################################################
+#####---------------------   START OF NCDF_VARS_EXIST FUNCTION      ----------------------------------####
+#  Open MPAS output and extract grid information and surface met data for comparision to MADIS obs
+#
+# Input:
+#       file   -- Model output file name. Full path and file name
+#       varid  -- Variable to search in file
+#
+# Output: Logial -- does the variable exist or not in file
+#
+ ncdf_vars_exist <- function(file, varid="swdnb") {
+
+  f1  <-nc_open(file)
+
+   nvars    <- length(f1$var[])
+   varexists<- F
+   for(n in 1:nvars){
+     #writeLines(paste("variable ID",n,"of",nvars,":",f1$var[[n]]$name))
+     if( varid == f1$var[[n]]$name) {
+       varexists<-T
+     }
+   }
+  nc_close(f1)
+
+  return(varexists)
+
+ }
+#####------------------    END OF NCDF_VARS_EXIST FUNCTION     ---------------------------------------####
+##########################################################################################################
 
 ##########################################################################################################
 #####--------------------------   START OF TEST FUNCTION          ------------------------------------####
@@ -35,6 +66,6 @@
   return()
 
  }
-#####--------------------------	  END OF TEST FUNCTION     -------------------------------------------####
+#####-------------------------  END OF TEST FUNCTION     -------------------------------------------####
 ##########################################################################################################
 

--- a/R_db_code/MET_model.read.R
+++ b/R_db_code/MET_model.read.R
@@ -8,32 +8,51 @@
 #####################################################################################################
 #######################################################################################################
 #
-#  V1.3, 2017Apr18, Robert Gilliam: Initial Development
-#  V1.4, 2018Sep30, Robert Gilliam: 
+#  V1.3, 2017Apr18, Robert Gilliam: Initial development
+#  V1.4, 2018Sep30, Robert Gilliam: Upper-air evaluation 
 #       - Added functions for reading model upper-air meteorology for
 #         matching to rawindsonde observations. Also computes what is not 
 #         explicitly in the model output. Profiles include pressure, height,
 #         temperature, rh, u and v wind components. Other values are included
 #         for potential future use for other obs sources like theta and q.
+#  V1.5, 2019Oct30, Robert Gilliam: 
+#       - Added functions for domains on other WRF map projections: 
+#         polar stereographic, mercator and regular lat-lon. All standard WRF projections 
+#         are now compatible with AMET.
+#       - 2020Aug15: QV is used in RH calcs instead of RH directly for consistency with WRF
+#                    if QV is in the MPAS output. 
+#       - 2020May12: Solar radiation and surface pressure are ignored if not in output since
+#                    they are not directly used in surface met matching, only BSRN matching. 
+#       - 2020Nov13: Added function for MCIP surface met compatibility (i.e., mcip_surface)
+#       - 2021Jan06: Added function for MCIP upper-air met compatibility (i.e., mcip_raob)
 #
 #######################################################################################################
 #     This script contains the following functions
-#
-#     mpas_surface       --> Open MPAS output and read surface variables to be
-#                            matched with MADIS surface observations. Also grabs grid 
-#                            structure information for matching obs to the grid.
 #
 #     wrf_surface        --> Open WRF output and read surface variables to be
 #                            matched with MADIS surface observations. Also grabs the 
 #                            projection information for obs matching. 
 #
-#     mpas_raob          --> Open MPAS output and read 3D met variables to be
-#                            matched with MADIS raob observations. Also grabs grid 
+#     mpas_surface       --> Open MPAS output and read surface variables to be
+#                            matched with MADIS surface observations. Also grabs grid 
+#                            structure information for matching obs to the grid.
+#
+#     mcip_surface       --> Open MCIP output and read surface variables to be
+#                            matched with MADIS surface observations. Also grabs grid 
 #                            structure information for matching obs to the grid.
 #
 #     wrf_raob           --> Open WRF output and read 3D met variables to be
 #                            matched with MADIS raob observations. Also grabs the 
 #                            projection information for obs matching.
+#
+#     mpas_raob          --> Open MPAS output and read 3D met variables to be
+#                            matched with MADIS raob observations. Also grabs grid 
+#                            structure information for matching obs to the grid.
+#
+#    mcip_raob           --> Open MCIP outputs and read 3D met variables to be
+#                            matched with MADIS raob observations. Also grabs the 
+#                            projection information for obs matching. A bit different
+#                            than WRF and MPAS, temp/rh and wind are in different files
 #
 #     model_time_format  --> Takes either MPAS or WRF timestamp and reformats for various AMET
 #                            functions and MySQL.
@@ -43,8 +62,136 @@
 #     lamb_latlon_to_ij  --> Find an i,j grid index for a latitude and longitude coordinate given
 #                            the model projection (Lambert Conformal only) definition.
 #
+#     polars_latlon_to_ij--> Find an i,j grid index for a latitude and longitude coordinate on
+#                            polar stereographic projection
+#
+#     mercat_latlon_to_ij--> Find an i,j grid index for a latitude and longitude coordinate on mercator grid
+#
+#     latlon_latlon_to_ij--> Find an i,j grid index for a latitude and longitude coordinate on lat-lon grid
+#
 #######################################################################################################
 #######################################################################################################
+
+##########################################################################################################
+#####--------------------------   START OF FUNCTION: WRF_SURFACE  ------------------------------------####
+#  Open WRF output and extract grid information and surface met data for comparision to MADIS obs
+# Input:
+#       file   -- Model output file name. Full path and file name
+#
+# Output: Multi-level list of model projection data and surface meteorology.
+#
+#  projection <-list(mproj=mproj, lat=lat, lon=lon, lat1=lat1, lon1=lon1, nx=nx, ny=ny, dx=dx,
+#                    truelat1=truelat1, truelat2=truelat2, standlon=standlon, conef=conef)
+#  sfc_met    <-list(time=time,t2=t2,q2=q2,u10=u10,v10=v10)
+
+ wrf_surface <-function(file) {
+
+  f1  <-nc_open(file)
+
+   head <- ncatt_get(f1, varid=0, attname="TITLE" )$value
+   time <- ncvar_get(f1, varid="Times")
+   mproj<- ncatt_get(f1, varid=0, attname="MAP_PROJ" )$value
+   
+   # WRF  1-Lamb     2-Polar    3-Merc      4- Lat-lon
+   if(mproj == 1){
+    lat1    <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(1,1,1))
+    lon1    <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(1,1,1))
+    lat     <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(-1,-1,1))
+    lon     <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(-1,-1,1))
+    nx      <- ncatt_get(f1, varid=0, attname="WEST-EAST_GRID_DIMENSION" )$value
+    ny      <- ncatt_get(f1, varid=0, attname="SOUTH-NORTH_GRID_DIMENSION" )$value
+    dx      <- ncatt_get(f1, varid=0, attname="DX" )$value
+    truelat1<- ncatt_get(f1, varid=0, attname="TRUELAT1" )$value
+    truelat2<- ncatt_get(f1, varid=0, attname="TRUELAT2" )$value
+    standlon<- ncatt_get(f1, varid=0, attname="STAND_LON" )$value
+   }
+
+   if(mproj == 2){
+    lat1      <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(1,1,1))
+    lon1      <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(1,1,1))
+    lat       <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(-1,-1,1))
+    lon       <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(-1,-1,1))
+    nx        <- ncatt_get(f1, varid=0, attname="WEST-EAST_GRID_DIMENSION" )$value
+    ny        <- ncatt_get(f1, varid=0, attname="SOUTH-NORTH_GRID_DIMENSION" )$value
+    dx        <- ncatt_get(f1, varid=0, attname="DX" )$value
+    truelat1  <- ncatt_get(f1, varid=0, attname="TRUELAT1" )$value
+    truelat2  <- ncatt_get(f1, varid=0, attname="TRUELAT2" )$value
+    standlon  <- ncatt_get(f1, varid=0, attname="STAND_LON" )$value
+   }
+
+   if(mproj == 3){
+    lat1      <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(1,1,1))
+    lon1      <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(1,1,1))
+    lat       <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(-1,-1,1))
+    lon       <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(-1,-1,1))
+    nx        <- ncatt_get(f1, varid=0, attname="WEST-EAST_GRID_DIMENSION" )$value
+    ny        <- ncatt_get(f1, varid=0, attname="SOUTH-NORTH_GRID_DIMENSION" )$value
+    dx        <- ncatt_get(f1, varid=0, attname="DX" )$value
+    truelat1  <- ncatt_get(f1, varid=0, attname="TRUELAT1" )$value
+    truelat2  <- ncatt_get(f1, varid=0, attname="TRUELAT2" )$value
+    standlon  <- ncatt_get(f1, varid=0, attname="STAND_LON" )$value
+   }
+
+   if(mproj == 4){
+    lat1      <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(1,1,1))
+    lon1      <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(1,1,1))
+    lat       <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(-1,-1,1))
+    lon       <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(-1,-1,1))
+    nx        <- ncatt_get(f1, varid=0, attname="WEST-EAST_GRID_DIMENSION" )$value
+    ny        <- ncatt_get(f1, varid=0, attname="SOUTH-NORTH_GRID_DIMENSION" )$value
+    dx        <- ncatt_get(f1, varid=0, attname="DX" )$value
+    truelat1  <- ncatt_get(f1, varid=0, attname="TRUELAT1" )$value
+    truelat2  <- ncatt_get(f1, varid=0, attname="TRUELAT2" )$value
+    standlon  <- ncatt_get(f1, varid=0, attname="STAND_LON" )$value
+   }
+
+   conef  <- cone(truelat1,truelat2)
+
+   # Required model vars for surface met evaluation
+   t2     <- ncvar_get(f1, varid="T2")
+   q2     <- ncvar_get(f1, varid="Q2")
+   u10    <- ncvar_get(f1, varid="U10")
+   v10    <- ncvar_get(f1, varid="V10")
+
+   # Not required for sfc met eval. But is for radiation eval and moisture timeseries
+   if(ncdf_vars_exist(file,"SWDOWN")) {
+     swr    <- ncvar_get(f1, varid="SWDOWN")
+   } else {
+     writeLines("** QAWARNING ** Shortwave radiation variable swdnb is not in output ")
+     writeLines("** QAWARNING ** Setting Shortwave radiation to 0. Do not evaluate!") 
+     swr   <- t2*0.0
+   }
+   if(ncdf_vars_exist(file,"PSFC")) {
+     psf    <- ncvar_get(f1, varid="PSFC")/1000
+   } else {
+     writeLines("** QAWARNING ** Shortwave radiation variable swdnb is not in output ")
+     writeLines("** QAWARNING ** Setting Shortwave radiation to 0. Do not evaluate!") 
+     psf   <- t2*0.0 + 100.12
+   }
+  nc_close(f1)
+  
+  # Check dimensions of met variables to determine if file has only 
+  # one time. If so, add a time dimension to the array for interpolation
+  # compatability. 
+  nt    <-length(time)
+  if( nt == 1 ) {
+    t2  <-array(t2,c(nx,ny,1))
+    q2  <-array(q2,c(nx,ny,1))
+    u10 <-array(u10,c(nx,ny,1))
+    v10 <-array(v10,c(nx,ny,1))
+    swr <-array(swr,c(nx,ny,1))
+    psf <-array(psf,c(nx,ny,1))
+  }
+
+  projection <-list(mproj=mproj, lat=lat, lon=lon, lat1=lat1, lon1=lon1, nx=nx, ny=ny, dx=dx,
+                    truelat1=truelat1, truelat2=truelat2, standlon=standlon, conef=conef)
+  sfc_met    <-list(time=time, t2=t2, q2=q2, u10=u10, v10=v10, swr=swr, psf=psf)
+  
+  return(list(projection=projection,sfc_met=sfc_met))
+
+ }
+#####--------------------------	  END OF FUNCTION: WRF_SURFACE     -----------------------------------####
+##########################################################################################################
 
 ##########################################################################################################
 #####--------------------------   START OF FUNCTION: MPAS_SURFACE  -----------------------------------####
@@ -63,20 +210,34 @@
 
   writeLines(paste("Reading MPAS Model Output File:",file))
   f1 <-nc_open(file)
+
+   # Required model vars for surface met evaluation
    lat    <- ncvar_get(f1, varid="latCell")
    lon    <- ncvar_get(f1, varid="lonCell")
    latv   <- ncvar_get(f1, varid="latVertex")
    lonv   <- ncvar_get(f1, varid="lonVertex")
    time   <- ncvar_get(f1, varid="xtime")
-
    cells_on_vertex <- ncvar_get(f1, varid="cellsOnVertex")
 
    t2     <- ncvar_get(f1, varid="t2m")
    q2     <- ncvar_get(f1, varid="q2")
    u10    <- ncvar_get(f1, varid="u10")
    v10    <- ncvar_get(f1, varid="v10")
-   swr    <- ncvar_get(f1, varid="swdnb")
-   psf    <- ncvar_get(f1, varid="surface_pressure")/1000
+
+   if(ncdf_vars_exist(file,"swdnb")) {
+     swr    <- ncvar_get(f1, varid="swdnb")
+   } else {
+     writeLines("** QAWARNING ** Shortwave radiation variable swdnb is not in output ")
+     writeLines("** QAWARNING ** Setting Shortwave radiation to 0. Do not evaluate!") 
+     swr   <- t2*0.0
+   }
+   if(ncdf_vars_exist(file,"surface_pressure")) {
+     psf    <- ncvar_get(f1, varid="surface_pressure")/1000
+   } else {
+     writeLines("** QAWARNING ** Shortwave radiation variable swdnb is not in output ")
+     writeLines("** QAWARNING ** Setting Shortwave radiation to 0. Do not evaluate!") 
+     psf   <- t2*0.0 + 100.12
+   }
   nc_close(f1)
 
   #swr    <-t2 * 0.0
@@ -117,8 +278,8 @@
 ##########################################################################################################
 
 ##########################################################################################################
-#####--------------------------   START OF FUNCTION: WRF_SURFACE  ------------------------------------####
-#  Open WRF output and extract grid information and surface met data for comparision to MADIS obs
+#####--------------------------   START OF FUNCTION: MCIP_SURFACE  ------------------------------------####
+#  Open MCIP output and extract grid information and surface met data for comparision to MADIS obs
 # Input:
 #       file   -- Model output file name. Full path and file name
 #
@@ -128,54 +289,150 @@
 #                    truelat1=truelat1, truelat2=truelat2, standlon=standlon, conef=conef)
 #  sfc_met    <-list(time=time,t2=t2,q2=q2,u10=u10,v10=v10)
 
- wrf_surface <-function(file) {
+ mcip_surface <-function(file) {
 
-  f1  <-nc_open(file)
+  # For MCIP, users must put a generic GRIDCRO2D file in the same directory
+  # as METCRO2D files. Lines below piece together directory location from "file"
+  # and set grid file name "gfile" to generic GRIDCRO2D.
+  # If user does not provide a GRIDCRO2D file in correct location, error message
+  # informs user of the mistep.
+  dirs     <-unlist(strsplit(file,split="/"))
+  ndirs    <-length(dirs)
+  gfile    <-paste(paste0(dirs[1:(ndirs-1)], collapse="/"),"/GRIDCRO2D",sep="")
+  if(file.exists(gfile)){
+     writeLines(paste("Reading supplied GRIDCRO2D for grid information:",gfile))
+     fg      <- nc_open(gfile)
+     head    <- ncatt_get(fg, varid=0, attname="EXEC_ID" )$value
+     tproj   <- ncatt_get(fg, varid=0, attname="GDTYP" )$value
+  }
+  else {
+     writeLines(paste("Terminating AMET."))
+     writeLines(paste("User must supply a single GRIDCRO2D as follows:",gfile))
+     quit(save="no")
+  }   
 
-   head <- ncatt_get(f1, varid=0, attname="TITLE" )$value
-   time <- ncvar_get(f1, varid="Times")
-   mproj<- ncatt_get(f1, varid=0, attname="MAP_PROJ" )$value
-   
+   # Note MCIP grid different from WRF grid numbers
+   # MCIP 1-lat/lon, 2-Lambert, 3-Mercator, 6- Polar Stereo
+   # WRF  1-Lamb     2-Polar    3-Merc      4- Lat-lon
+   if(tproj != 1 & tproj !=2 & tproj !=3 & tproj !=6) { 
+     writeLines(paste("Grid projection not compatible. Has to be 1, 2, 3 or 6."))
+     writeLines(paste("Terminating AMET. Projection has to be lat-lon, lambert, Merc or PolarS."))
+     quit(save="no")
+   }
+   # Mapping MCIP Proj numbering to WRF 
+   if(tproj == 1) { mproj <- 4 }
+   if(tproj == 2) { mproj <- 1 }
+   if(tproj == 3) { mproj <- 3 }
+   if(tproj == 6) { mproj <- 2 }
+
    if(mproj == 1){
-    lat1    <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(1,1,1))
-    lon1    <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(1,1,1))
-    lat     <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(-1,-1,1))
-    lon     <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(-1,-1,1))
-    nx      <- ncatt_get(f1, varid=0, attname="WEST-EAST_GRID_DIMENSION" )$value
-    ny      <- ncatt_get(f1, varid=0, attname="SOUTH-NORTH_GRID_DIMENSION" )$value
-    dx      <- ncatt_get(f1, varid=0, attname="DX" )$value
-    truelat1<- ncatt_get(f1, varid=0, attname="TRUELAT1" )$value
-    truelat2<- ncatt_get(f1, varid=0, attname="TRUELAT2" )$value
-    standlon<- ncatt_get(f1, varid=0, attname="STAND_LON" )$value
+    lat1    <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(1,1,1,1))
+    lon1    <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(1,1,1,1))
+    lat     <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    lon     <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    nx      <- ncatt_get(fg, varid=0, attname="NCOLS" )$value
+    ny      <- ncatt_get(fg, varid=0, attname="NROWS" )$value
+    dx      <- ncatt_get(fg, varid=0, attname="XCELL" )$value
+    truelat1<- ncatt_get(fg, varid=0, attname="P_ALP" )$value
+    truelat2<- ncatt_get(fg, varid=0, attname="P_BET" )$value
+    standlon<- ncatt_get(fg, varid=0, attname="P_GAM" )$value
    }
-
    if(mproj == 2){
-    lat1      <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(1,1,1))
-    lon1      <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(1,1,1))
-    lat       <- ncvar_get(f1, varid="XLAT",start=c(1,1,1),count=c(-1,-1,1))
-    lon       <- ncvar_get(f1, varid="XLONG",start=c(1,1,1),count=c(-1,-1,1))
-    nx        <- ncatt_get(f1, varid=0, attname="WEST-EAST_GRID_DIMENSION" )$value
-    ny        <- ncatt_get(f1, varid=0, attname="SOUTH-NORTH_GRID_DIMENSION" )$value
-    dx        <- ncatt_get(f1, varid=0, attname="DX" )$value
-    truelat1  <- ncatt_get(f1, varid=0, attname="TRUELAT1" )$value
-    truelat2  <- ncatt_get(f1, varid=0, attname="TRUELAT2" )$value
-    standlon  <- ncatt_get(f1, varid=0, attname="STAND_LON" )$value
+    lat1    <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(1,1,1,1))
+    lon1    <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(1,1,1,1))
+    lat     <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    lon     <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    nx      <- ncatt_get(fg, varid=0, attname="NCOLS" )$value
+    ny      <- ncatt_get(fg, varid=0, attname="NROWS" )$value
+    dx      <- ncatt_get(fg, varid=0, attname="XCELL" )$value
+    truelat1<- ncatt_get(fg, varid=0, attname="P_ALP" )$value
+    truelat2<- ncatt_get(fg, varid=0, attname="P_BET" )$value
+    standlon<- ncatt_get(fg, varid=0, attname="P_GAM" )$value
    }
-   conef  <- cone(truelat1,truelat2)
+   if(mproj == 3){
+    lat1    <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(1,1,1,1))
+    lon1    <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(1,1,1,1))
+    lat     <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    lon     <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    nx      <- ncatt_get(fg, varid=0, attname="NCOLS" )$value
+    ny      <- ncatt_get(fg, varid=0, attname="NROWS" )$value
+    dx      <- ncatt_get(fg, varid=0, attname="XCELL" )$value
+    truelat1<- ncatt_get(fg, varid=0, attname="P_ALP" )$value
+    truelat2<- ncatt_get(fg, varid=0, attname="P_BET" )$value
+    standlon<- ncatt_get(fg, varid=0, attname="P_GAM" )$value
+   }
 
-   t2     <- ncvar_get(f1, varid="T2")
-   q2     <- ncvar_get(f1, varid="Q2")
-   u10    <- ncvar_get(f1, varid="U10")
-   v10    <- ncvar_get(f1, varid="V10")
-   swr    <- ncvar_get(f1, varid="SWDOWN")
-   psf    <- ncvar_get(f1, varid="PSFC")/1000
+   if(mproj == 4){
+    lat1    <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(1,1,1,1))
+    lon1    <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(1,1,1,1))
+    lat     <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    lon     <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    nx      <- ncatt_get(fg, varid=0, attname="NCOLS" )$value
+    ny      <- ncatt_get(fg, varid=0, attname="NROWS" )$value
+    dx      <- ncatt_get(fg, varid=0, attname="XCELL" )$value
+    truelat1<- ncatt_get(fg, varid=0, attname="P_ALP" )$value
+    truelat2<- ncatt_get(fg, varid=0, attname="P_BET" )$value
+    standlon<- ncatt_get(fg, varid=0, attname="P_GAM" )$value
+   }
+   nc_close(fg)
+
+   # MCIP wind dir is adjusted to true north from grid relative north in WRF
+   # A readjustment back to WRF is required before U and V are caculated.
+   # This adjustment is added to MCIP WD10 in time loop below.
+   conef    <- cone(truelat1,truelat2)
+   wdadjust <- (standlon-lon)*conef
    
+  # Required model vars for surface met evaluation
+  f1  <-nc_open(file)
+   t2     <- ncvar_get(f1, varid="TEMP2")
+   q2     <- ncvar_get(f1, varid="Q2")
+   ws10   <- ncvar_get(f1, varid="WSPD10")
+   wd10   <- ncvar_get(f1, varid="WDIR10")
+
+   ## Need to use date functions to convert date from Julian (Models3) to month and day
+   ## and replicate date/time string of WRF and MPAS
+   jdate <-ncvar_get(f1, varid="TFLAG",start=c(1,1,1), count=c(1,1,-1))
+   utc   <-ncvar_get(f1, varid="TFLAG",start=c(2,1,1), count=c(1,1,-1))
+   nt    <-length(jdate)
+   time  <- array(NA,c(nt))
+   for(tt in 1:nt){
+     aa       <- unlist(strsplit(as.character(jdate[tt]),""))
+     tmpy     <- as.numeric(paste(aa[1],aa[2],aa[3],aa[4],sep=""))
+     tmpjd    <- as.numeric(paste(aa[5],aa[6],aa[7],sep=""))
+     dates    <- date.mmddyyyy( mdy.date(1,1,tmpy)-as.date(1)+ tmpjd )
+     tmpm     <- sprintf("%02.f",as.numeric(unlist(strsplit(dates,"/"))[1]))
+     tmpd     <- sprintf("%02.f",as.numeric(unlist(strsplit(dates,"/"))[2]))
+     time[tt] <-paste(tmpy,"-",tmpm,"-",tmpd,"_",sprintf("%02.f",utc[tt]/10000),":00:00",sep="")
+
+     # WD adjustment
+     wd10[,,tt]<- wd10[,,tt] + wdadjust
+   }
+
+   ## NEED to convert WS & WD to U10 V10.
+   u10    <-(-1)*ws10*sin(wd10*pi/180)
+   v10    <-(-1)*ws10*cos(wd10*pi/180)
+
+
+   # Not required for sfc met eval. But is for radiation eval and moisture timeseries
+   if(ncdf_vars_exist(file,"RGRND")) {
+     swr    <- ncvar_get(f1, varid="RGRND")
+   } else {
+     writeLines("** QAWARNING ** Shortwave radiation variable swdnb is not in output ")
+     writeLines("** QAWARNING ** Setting Shortwave radiation to 0. Do not evaluate!") 
+     swr   <- t2*0.0
+   }
+   if(ncdf_vars_exist(file,"PRSFC")) {
+     psf    <- ncvar_get(f1, varid="PRSFC")/1000
+   } else {
+     writeLines("** QAWARNING ** Shortwave radiation variable swdnb is not in output ")
+     writeLines("** QAWARNING ** Setting Shortwave radiation to 0. Do not evaluate!") 
+     psf   <- t2*0.0 + 100.12
+   }
   nc_close(f1)
   
   # Check dimensions of met variables to determine if file has only 
   # one time. If so, add a time dimension to the array for interpolation
   # compatability. 
-  nt    <-length(time)
   if( nt == 1 ) {
     t2  <-array(t2,c(nx,ny,1))
     q2  <-array(q2,c(nx,ny,1))
@@ -192,7 +449,7 @@
   return(list(projection=projection,sfc_met=sfc_met))
 
  }
-#####--------------------------	  END OF FUNCTION: WRF_SURFACE     -----------------------------------####
+#####--------------------------	  END OF FUNCTION: MCIP_SURFACE     -----------------------------------####
 ##########################################################################################################
 
 ##########################################################################################################
@@ -334,12 +591,21 @@
    hgt   <- ncvar_get(f1, varid="zgrid")
    p     <- ncvar_get(f1, varid="pressure", start=c(1,1,t),count=c(-1,-1,1))/100
    theta <- ncvar_get(f1, varid="theta", start=c(1,1,t),count=c(-1,-1,1))
-   rh    <- ncvar_get(f1, varid="relhum", start=c(1,1,t),count=c(-1,-1,1))
+   rh_tmp<- ncvar_get(f1, varid="relhum", start=c(1,1,t),count=c(-1,-1,1))
    u     <- ncvar_get(f1, varid="uReconstructZonal", start=c(1,1,t),count=c(-1,-1,1))
    v     <- ncvar_get(f1, varid="uReconstructMeridional", start=c(1,1,t),count=c(-1,-1,1))
    pblh  <- ncvar_get(f1, varid="hpbl", start=c(1,t),count=c(-1,1))
    psf   <- ncvar_get(f1, varid="surface_pressure", start=c(1,t),count=c(-1,1))/100
    elev  <- hgt[1,]
+
+   if(ncdf_vars_exist(file,"qv")) {
+     qv      <- ncvar_get(f1, varid="qv", start=c(1,1,t),count=c(-1,-1,1))
+     qv.flag <- T
+     writeLines("** QAWARNING ** QV IS in output. Will calculate RH from QV and T. ")
+   } else {
+     qv.flag <- F
+     writeLines("** QAWARNING ** QV is not in output. Will use RH output for RH ")
+   }
 
   nc_close(f1)
 
@@ -353,7 +619,16 @@
   tk     <- theta / (1000/p) ^ 0.2857143
   e      <- 0.611 * exp ( (2.501E6/461.5) * ( (1/273.14) -(1/tk) ) )
   mixrs  <- 0.62197 * (e/(p/10))
-  qv     <- rh*mixrs/100
+
+  if(qv.flag) {
+   rh    <- 100*(qv/mixrs)
+   rh    <- ifelse(rh > 100,100,rh)
+   rh    <- ifelse(rh < 0.0,0.1,rh)
+  }
+  else {
+   rh     <- rh_tmp
+   qv     <- rh*mixrs/100
+  }
 
   # Calcuate full level heigh above ground level and center height of full levels
   levzh      <- p*0.0
@@ -385,6 +660,200 @@
 
  }
 #####--------------------------	  END OF FUNCTION: MPAS_RAOB       -----------------------------------####
+##########################################################################################################
+
+##########################################################################################################
+#####--------------------------   START OF FUNCTION: MCIP_RAOB    ------------------------------------####
+#  Open MCIP outputs (METCRO3D & METDOT3D) for matching to MADIS RAOB profiles
+#  Also opens GRIDCRO and GRIDDOT grid files for grid/proj information.
+# Input:
+#       file   -- Model output file name. Full path and file name
+#          t   -- Time index to get. Unlike surface met, this was added to
+#                 cut down on array size in memory instead of grabbing all times at once.
+#
+# Output: Multi-level list of model projection data and sounding meteorology.
+#
+#  projection <-list(mproj=mproj, lat=lat, lon=lon, lat1=lat1, lon1=lon1, nx=nx, ny=ny, dx=dx,
+#                    truelat1=truelat1, truelat2=truelat2, standlon=standlon, conef=conef)
+#  raob_met    <-list(time=time, elev=elev, sigu=sigu, sigm=sigm, u=u, v=v, theta=theta, temp=tk,
+#                      qv=qv, rh=rh, pblh=pblh, psf=psf, p=p, levzf=levzf, levzh=levzh)
+
+ mcip_raob <-function(file,t=1) {
+
+  # MCIP presents some challanges. 8-9 files for each WRF/MPAS output.
+  # For surface matching a generic grid file + and a list of METCRO2D files simplified the processing.
+  # For MCIP raob matching, a grid file and list of METCRO3D and METDOT3D files complicates processing.
+  # To account for this users have to run AMET raob for each batch of MCIP files.
+  # This mcip_raob() function will look for generic GRIDCRO2D, METCRO3D and METDOT3D files
+  # in the model output directory specified in the run script.
+  dirs     <-unlist(strsplit(file,split="/"))
+  ndirs    <-length(dirs)
+  gfilec   <-paste(paste0(dirs[1:(ndirs-1)], collapse="/"),"/GRIDCRO2D",sep="")
+  mfilec   <-paste(paste0(dirs[1:(ndirs-1)], collapse="/"),"/METCRO3D",sep="")
+  mfiled   <-paste(paste0(dirs[1:(ndirs-1)], collapse="/"),"/METDOT3D",sep="")
+  if(file.exists(gfilec)){
+     writeLines(paste("Reading supplied GRIDCRO2D for grid information:",gfilec))
+     fg     <- nc_open(gfilec)
+     head   <- ncatt_get(fg, varid=0, attname="EXEC_ID" )$value
+     tproj  <- ncatt_get(fg, varid=0, attname="GDTYP" )$value
+     elev   <- ncvar_get(fg, varid="HT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+  }
+  else {
+     writeLines(paste("Terminating AMET."))
+     writeLines(paste("User must supply a single GRIDCRO2D as follows to run MCIP RAOB:",gfilec))
+     quit(save="no")
+  }   
+  if(file.exists(mfilec)){
+     writeLines(paste("Reading supplied METCRO3D for grid information:",mfilec))
+  }
+  else {
+     writeLines(paste("Terminating AMET."))
+     writeLines(paste("User must supply a METCRO3D file as follows to run MCIP RAOB:",mfilec))
+     quit(save="no")
+  }   
+  if(file.exists(mfiled)){
+     writeLines(paste("Reading supplied METCRO3D for grid information:",mfiled))
+  }
+  else {
+     writeLines(paste("Terminating AMET."))
+     writeLines(paste("User must supply a METDOT3D file as follows to run MCIP RAOB:",mfiled))
+     quit(save="no")
+  }   
+
+   # Note MCIP grid different from WRF grid numbers
+   # MCIP 1-lat/lon, 2-Lambert, 3-Mercator, 6- Polar Stereo
+   # WRF  1-Lamb     2-Polar    3-Merc      4- Lat-lon
+   if(tproj != 1 & tproj !=2 & tproj !=3 & tproj !=6) { 
+     writeLines(paste("Grid projection not compatible. Has to be 1, 2, 3 or 6."))
+     writeLines(paste("Terminating AMET. Projection has to be lat-lon, lambert, Merc or PolarS."))
+     quit(save="no")
+   }
+   # Mapping MCIP Proj numbering to WRF 
+   if(tproj == 1) { mproj <- 4 }
+   if(tproj == 2) { mproj <- 1 }
+   if(tproj == 3) { mproj <- 3 }
+   if(tproj == 6) { mproj <- 2 }
+
+   if(mproj == 1){
+    lat1    <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(1,1,1,1))
+    lon1    <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(1,1,1,1))
+    lat     <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    lon     <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    nx      <- ncatt_get(fg, varid=0, attname="NCOLS" )$value
+    ny      <- ncatt_get(fg, varid=0, attname="NROWS" )$value
+    dx      <- ncatt_get(fg, varid=0, attname="XCELL" )$value
+    truelat1<- ncatt_get(fg, varid=0, attname="P_ALP" )$value
+    truelat2<- ncatt_get(fg, varid=0, attname="P_BET" )$value
+    standlon<- ncatt_get(fg, varid=0, attname="P_GAM" )$value
+   }
+   if(mproj == 2){
+    lat1    <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(1,1,1,1))
+    lon1    <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(1,1,1,1))
+    lat     <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    lon     <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    nx      <- ncatt_get(fg, varid=0, attname="NCOLS" )$value
+    ny      <- ncatt_get(fg, varid=0, attname="NROWS" )$value
+    dx      <- ncatt_get(fg, varid=0, attname="XCELL" )$value
+    truelat1<- ncatt_get(fg, varid=0, attname="P_ALP" )$value
+    truelat2<- ncatt_get(fg, varid=0, attname="P_BET" )$value
+    standlon<- ncatt_get(fg, varid=0, attname="P_GAM" )$value
+   }
+   if(mproj == 3){
+    lat1    <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(1,1,1,1))
+    lon1    <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(1,1,1,1))
+    lat     <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    lon     <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    nx      <- ncatt_get(fg, varid=0, attname="NCOLS" )$value
+    ny      <- ncatt_get(fg, varid=0, attname="NROWS" )$value
+    dx      <- ncatt_get(fg, varid=0, attname="XCELL" )$value
+    truelat1<- ncatt_get(fg, varid=0, attname="P_ALP" )$value
+    truelat2<- ncatt_get(fg, varid=0, attname="P_BET" )$value
+    standlon<- ncatt_get(fg, varid=0, attname="P_GAM" )$value
+   }
+
+   if(mproj == 4){
+    lat1    <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(1,1,1,1))
+    lon1    <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(1,1,1,1))
+    lat     <- ncvar_get(fg, varid="LAT",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    lon     <- ncvar_get(fg, varid="LON",start=c(1,1,1,1),count=c(-1,-1,1,1))
+    nx      <- ncatt_get(fg, varid=0, attname="NCOLS" )$value
+    ny      <- ncatt_get(fg, varid=0, attname="NROWS" )$value
+    dx      <- ncatt_get(fg, varid=0, attname="XCELL" )$value
+    truelat1<- ncatt_get(fg, varid=0, attname="P_ALP" )$value
+    truelat2<- ncatt_get(fg, varid=0, attname="P_BET" )$value
+    standlon<- ncatt_get(fg, varid=0, attname="P_GAM" )$value
+   }
+   nc_close(fg)
+
+   # MCIP wind dir is adjusted to true north from grid relative north in WRF
+   # A readjustment back to WRF is required before U and V are caculated.
+   # This adjustment is added to MCIP WD10 in time loop below.
+   conef    <- cone(truelat1,truelat2)
+   wdadjust <- (standlon-lon)*conef
+
+  f1  <-nc_open(mfilec)
+   jdate  <-ncvar_get(f1, varid="TFLAG",start=c(1,1,1), count=c(1,1,-1))
+   utc    <-ncvar_get(f1, varid="TFLAG",start=c(2,1,1), count=c(1,1,-1))
+   sigm   <- ncatt_get(f1, varid=0, attname="VGLVLS" )$value
+   p      <- ncvar_get(f1, varid="PRES", start=c(1,1,1,t),count=c(-1,-1,-1,1))/100
+   qv     <- ncvar_get(f1, varid="QV",   start=c(1,1,1,t),count=c(-1,-1,-1,1))
+   tk     <- ncvar_get(f1, varid="TA",   start=c(1,1,1,t),count=c(-1,-1,-1,1))
+   levzh  <- ncvar_get(f1, varid="ZH",   start=c(1,1,1,t),count=c(-1,-1,-1,1))
+   levzf  <- ncvar_get(f1, varid="ZF",   start=c(1,1,1,t),count=c(-1,-1,-1,1))
+   psf    <- ncvar_get(f1, varid="PRES", start=c(1,1,1,t),count=c(-1,-1,1,1))/100
+  nc_close(f1)
+
+  f1  <-nc_open(mfiled)
+   u      <- ncvar_get(f1, varid="UWIND",start=c(1,1,1,t),count=c(-1,-1,-1,1))
+   v      <- ncvar_get(f1, varid="VWIND",start=c(1,1,1,t),count=c(-1,-1,-1,1))
+  nc_close(f1)
+
+   ## Need to use date functions to convert date from Julian (Models3) to month and day
+   ## and replicate date/time string of WRF and MPAS
+   nt    <-length(jdate)
+   time  <- array(NA,c(nt))
+   for(tt in 1:nt){
+     aa       <- unlist(strsplit(as.character(jdate[tt]),""))
+     tmpy     <- as.numeric(paste(aa[1],aa[2],aa[3],aa[4],sep=""))
+     tmpjd    <- as.numeric(paste(aa[5],aa[6],aa[7],sep=""))
+     dates    <- date.mmddyyyy( mdy.date(1,1,tmpy)-as.date(1)+ tmpjd )
+     tmpm     <- sprintf("%02.f",as.numeric(unlist(strsplit(dates,"/"))[1]))
+     tmpd     <- sprintf("%02.f",as.numeric(unlist(strsplit(dates,"/"))[2]))
+     time[tt] <-paste(tmpy,"-",tmpm,"-",tmpd,"_",sprintf("%02.f",utc[tt]/10000),":00:00",sep="")
+   }
+
+  # Sigma levels are not currently used for any analysis, but for completness the 
+  # full levels are an attribute in METCRO3D. Half levels sigma is computed.
+  nzf <-length(sigm)
+  nzh <-nzf-1
+  sigu   <- array(NA,c(nzh))
+  for(z in 1:nzh){
+   sigu[z]<- 0.5 * (sigm[z]+sigm[z+1])
+  }
+
+  # Some calcs to derive variables needed for other calcs and comp to obs profiles
+  # i.e., theta, satmixr and RH
+  theta  <- tk * (1000/p)^ 0.2857143 
+
+  e      <- 0.611 * exp ( (2.501E6/461.5) * ( (1/273.14) -(1/tk) ) )
+  mixrs  <- 0.62197 * (e/(p/10))
+  rh     <- 100*(qv/mixrs)
+  rh     <- ifelse(rh > 100,100,rh)
+  rh     <- ifelse(rh < 0.0,0.1,rh)
+
+  # PBL height is extracted and part of the met data, but not used at this time
+  # In WRF and MPAS this is in the output file, but not in MCIP METCRO3D so set 0.
+  pblh   <- psf*0
+  
+  projection <-list(mproj=mproj, lat=lat, lon=lon, lat1=lat1, lon1=lon1, nx=nx, ny=ny, dx=dx,
+                    truelat1=truelat1, truelat2=truelat2, standlon=standlon, conef=conef)
+  raob_met    <-list(time=time, elev=elev, sigu=sigu, sigm=sigm, u=u, v=v, theta=theta, temp=tk,
+                      qv=qv, rh=rh, pblh=pblh, psf=psf, p=p, levzf=levzf, levzh=levzh)
+  
+  return(list(projection=projection, raob_met=raob_met))
+
+ }
+#####--------------------------	  END OF FUNCTION: MCIP_RAOB        ----------------------------------####
 ##########################################################################################################
 
 ##########################################################################################################
@@ -459,8 +928,8 @@
 #        reflon  -- Longitude of a reference point of the grid. Typically lower left corner of the domain
 #        iref    -- I index of the reference point.
 #        jref    -- J index of the reference point.
-#        stdlt1  -- first true latitude of the projection
-#        stdlt2  -- second true latitude of the projection
+#        truelat1-- first true latitude of the projection
+#        truelat2-- second true latitude of the projection
 #        stdlon  -- center longitude of the LC projection
 #        delx    -- grid spacing in meters
 #        grdlat  -- Latitude of point of interest (usually an observation location)
@@ -469,21 +938,9 @@
 #
 # Output: List with i and j index values in fractional form
 
- lamb_latlon_to_ij <- function(reflat, reflon, iref, jref, stdlt1, stdlt2,
+ lamb_latlon_to_ij <- function(reflat, reflon, iref, jref, truelat1, truelat2,
                                stdlon, delx, grdlat, grdlon, radius= 6370000.0) {
 
-#reflat  <- 20.8568
-#reflon  <- -121.492
-#iref    <- 1
-#jref    <- 1
-#stdlt1  <- 33.0
-#stdlt2  <- 45.0
-#stdlon  <- -97.0
-#delx    <-12000
-#dely    <-12000
-#radius  <- 6370000.0
-#grdlat<-obs$meta$slat[7731]
-#grdlon<-obs$meta$slon[7731]
 
    pi     <- 4.0*atan(1.0)
    pi2    <- pi/2.0
@@ -492,16 +949,16 @@
    r2d    <- 180.0/pi
    omega4 <- 4.0*pi/86400.0
 
-   if(stdlt1 == stdlt2) {
-     gcon <- sin( abs(stdlt1) * d2r)
+   if(truelat1 == truelat2) {
+     gcon <- sin( abs(truelat1) * d2r)
    } else {
-     gcon <- (log(sin((90.0- abs(stdlt1))* d2r))-log(sin((90.0- abs(stdlt2))* d2r)))/
-             (log(tan((90.0- abs(stdlt1))*0.5* d2r))-log(tan((90.0- abs(stdlt2))*0.5* d2r)))
+     gcon <- (log(sin((90.0- abs(truelat1))* d2r))-log(sin((90.0- abs(truelat2))* d2r)))/
+             (log(tan((90.0- abs(truelat1))*0.5* d2r))-log(tan((90.0- abs(truelat2))*0.5* d2r)))
    }
 
    ogcon  <- 1.0/gcon
-   ahem   <- abs( stdlt1 / stdlt1 )
-   deg    <- (90.0- abs(stdlt1)) * d2r
+   ahem   <- abs( truelat1 / truelat1 )
+   deg    <- (90.0- abs(truelat1)) * d2r
    cn1    <- sin(deg)
    cn2    <- radius * cn1 * ogcon
    deg    <- deg * 0.5
@@ -537,6 +994,150 @@
  }
 #####--------------------------	  END OF FUNCTION: LAMB_LATLON_TO_IJ  --------------------------------####
 ##########################################################################################################
+
+##########################################################################################################
+#####-------------------   START OF FUNCTION: POLARS_LATLON_TO_IJ       ------------------------------####
+# Cacluation of i and j index of a specified latitude and longitude for a given lambert conformal
+# projection. Note: Calculations derived from Obsgrid Code
+# Input:
+#        reflat  -- Latitude of a reference point of the grid. Typically lower left corner of the domain
+#        reflon  -- Longitude of a reference point of the grid. Typically lower left corner of the domain
+#        truelat1-- first true latitude of the projection
+#        stdlon  -- center longitude of the LC projection
+#        delx    -- grid spacing in meters
+#        lato    -- Latitude of point of interest (usually an observation location)
+#        lono    -- Longitude of point of interest (usually an observation location)
+#        radius  -- Radius of the earth in meters. Default is current value for WRF and MPAS
+#
+# Output: List with i and j index values in fractional form
+
+ polars_latlon_to_ij <- function(lat1, lon1, delx, truelat1, stdlon, 
+                                 lato, lono, radius= 6370000.0) {
+
+  rad_per_deg <- pi/180
+  deg_per_rad <- 180/pi
+
+  reflon      <- stdlon + 90.
+  
+  hemi   <- 1
+  if(truelat1 < 0) {
+    hemi <- -1
+  }
+
+  rebydx    <- radius / delx
+  scale_top <- 1. + hemi * sin(truelat1 * rad_per_deg)
+  
+  ala1      <- lat1 * rad_per_deg
+  rsw       <- rebydx*cos(ala1)*scale_top/(1.+hemi*sin(ala1))
+
+  alo1      <- (lon1 - reflon) * rad_per_deg
+  polei     <- 1. - rsw * cos(alo1)
+  polej     <- 1. - hemi * rsw * sin(alo1)
+
+
+  ala       <- lato * rad_per_deg
+  rm        <- rebydx * cos(ala) * scale_top/(1. + hemi *sin(ala))
+  alo       <- (lono - reflon) * rad_per_deg
+  grdi      <- polei + rm * cos(alo)
+  grdj      <- polej + hemi * rm * sin(alo)
+
+
+  return(list(i=round(grdi), j=round(grdj)))
+
+ }
+#####--------------------------	  END OF FUNCTION: POLARS_LATLON_TO_IJ  ------------------------------####
+##########################################################################################################
+
+##########################################################################################################
+##########################################################################################################
+#####-------------------   START OF FUNCTION: MERCAT_LATLON_TO_IJ       ------------------------------####
+# Cacluation of i and j index of a specified latitude and longitude for a given mercator projection.
+# Note: Calculations derived from Obsgrid Code
+# Input:
+#        reflat  -- Latitude of a reference point of the grid. Typically lower left corner of the domain
+#        reflon  -- Longitude of a reference point of the grid. Typically lower left corner of the domain
+#        lat     -- Latitude array (2D) of domain gridpoints
+#        lon     -- Longitude array (2D) of domain gridpoints
+#        dx      -- Grid spacing in meters
+#        stdlt1  -- first true latitude of the projection
+#        lato    -- Latitude of point of interest (usually an observation location)
+#        lono    -- Longitude of point of interest (usually an observation location)
+#        radius  -- Earth radius in model (m) default is set to WRF.
+#
+# Output: List with i and j index values in fractional form
+
+ mercat_latlon_to_ij <- function(reflat, reflon, lat, lon, dx, stdlt1, lato, lono, radius= 6370000.0) {
+
+  # Calcuation used in Obsgrid for Mercator. Saved here for possible use in the future.
+  rad_per_deg <- pi/180
+  deg_per_rad <- 180/pi
+
+  lon0 <- reflon
+  if(lon0 < 0) {
+    lon0 <- 360+lon0
+  } 
+
+  lon360 <- lono
+  if(lon360 < 0) {
+    lon360 <- 360+lon360
+  } 
+
+  clain  <- cos(rad_per_deg*stdlt1)
+  dlon   <- dx / (radius * clain)
+
+  rsw <- 0.
+  if(reflat != 0) {
+     rsw <- (log(tan(0.5*((reflat+90.)*rad_per_deg))))/dlon
+  }
+
+
+  deltalon <- lon360 - lon0
+  deltalat <- lato - reflat
+
+  grdi <- 1. + (deltalon/(dlon*deg_per_rad))
+  grdj <- 1. + (log(tan(0.5*((lato + 90.) * rad_per_deg)))) / dlon - rsw
+
+  # More direct calculation that finds closest grid point using min distance
+  # between site lat-lon and all grid point lat-lons.
+  d    <- sqrt( (lato-lat)^2 + (lono-lon)^2 )
+  ind  <- which(d == min(d), arr.ind =T)
+  grdi <-ind[1]
+  grdj <-ind[2]
+
+  return(list(i=round(grdi), j=round(grdj)))
+
+ }
+#####--------------------------	  END OF FUNCTION: MERCAT_LATLON_TO_IJ  --------------------------------####
+##########################################################################################################
+
+##########################################################################################################
+##########################################################################################################
+#####-------------------   START OF FUNCTION: LATLON_LATLON_TO_IJ         ------------------------------####
+# Cacluation of i and j index of a specified latitude and longitude for a given lat-lon projection.
+# 
+# Input:
+#        lat     -- Latitude array (2D) of domain gridpoints
+#        lon     -- Longitude array (2D) of domain gridpoints
+#        lato    -- Latitude of point of interest (usually an observation location)
+#        lono    -- Longitude of point of interest (usually an observation location)
+#
+# Output: List with i and j index values in fractional form
+
+ latlon_latlon_to_ij <- function(lat, lon, lato, lono) {
+
+  # More direct calculation that finds closest grid point using min distance
+  # between site lat-lon and all grid point lat-lons.
+  d    <- sqrt( (lato-lat)^2 + (lono-lon)^2 )
+  ind  <- which(d == min(d), arr.ind =T)
+  grdi <-ind[1]
+  grdj <-ind[2]
+
+  return(list(i=grdi, j=grdj))
+
+ }
+#####--------------------------	  END OF FUNCTION: LATLON_LATLON_TO_IJ  --------------------------------####
+##########################################################################################################
+
 
 #         XCART = M_XGRID(LAT,LON,X_POLE_U,LAT_TRUE_U,LON_XX_U)
 #         YCART = M_YGRID(LAT,LON,Y_POLE_U,LAT_TRUE_U,LON_XX_U)


### PR DESCRIPTION
All update descriptions are in the individual code headers as well, but all are copied below for detailed updates of each code.

MET_matching_bsrn.R
         - Added controls for MCIP compatibility. Main updates made in MET_model_read.R.
         - MPAS limited area mesh are compatible. Interp weights are NA for sites not in the domain
         - Added forecast cycle and forecast hour in the case of forecast model eval.
         - Temp text query files pushed to MySQL file naming was changed by adding a random large
           number in the name (num between 1-100000). This allows multiple threads at the same time
           in the same project directory.


MET_matching_raob.R 
         - Added controls for MCIP compatibility. Main updates made in MET_model_read.R.
         - MPAS limited area mesh are compatible. Interp weights are NA for sites not in the domain
         - Added forecast cycle and forecast hour in the case of forecast model eval.
         - Temp text query files pushed to MySQL file naming was changed by adding a random large
           number in the name (num between 1-100000). This allows multiple threads at the same time
           in the same project directory.


MET_matching_surface.R
         - Added controls for MCIP compatibility. Main updates made in MET_model_read.R.
         - MPAS limited area mesh are compatible. Interp weights are NA for sites not in the domain
         - Added forecast cycle and forecast hour in the case of forecast model eval.
         - Temp text query files pushed to MySQL file naming was changed by adding a random large
           number in the name (num between 1-100000). This allows multiple threads at the same time
           in the same project directory.

MET_misc.R
         - Added a function to check if variable exist in NetCDF file

MET_model.read.R
       - Added functions for domains on other WRF map projections: 
         polar stereographic, mercator and regular lat-lon. All standard WRF projections 
         are now compatible with AMET.
       - 2020Aug15: QV is used in RH calcs instead of RH directly for consistency with WRF
       - 2020May12: Solar radiation and surface pressure are ignored if not in output since
                    they are not directly used in surface met matching, only BSRN matching. 
       - 2020Nov13: Added function for MCIP surface met compatibility (i.e., mcip_surface)
       - 2021Jan06: Added function for MCIP upper-air met compatibility (i.e., mcip_raob)


MET_observation.read.R
  V1.5, 2021Apr20, Robert Gilliam:
       - Added function to check if file is empty. 
       - Fixed error messages when obs file download fails. Download.file function creates empty local file 
         when remote file is missing. Then attempts to unzip. Fix checks size of file and deletes the empties.
       - Code clean and format. Found numerous functions that did not have proper informational headings.


MET_site.mapping.R
  V1.5, 2019Oct30, Robert Gilliam: 
       - Added calls i,j grid index for domains on other WRF map projections:
         polar stereog, mercator and regular lat-lon. 
  V1.5, 2020Jan15, Robert Gilliam: 
       - Made changes to mpas_site_map for limited-area MPAS grids where sites can be outside
         of the model domain. Prior it was assumed global so no checks on site-to-model indexing.
  V1.5, 2020Feb26, Robert Gilliam: 
       - Added random number to site query filename for multiple runs in the same directory
       - Old MADIS datasets have site(s) with NA for lat-lon coordinates. Check and skip those now. 

MET_dbase.R
  V1.5, 2020Feb21, Robert Gilliam: 
        - Fixed level bug in raob_query functions that in some cases produced Inf values. Skips now.


