### PR TITLE
Master metadata file for State and Country

### DIFF
--- a/R_db_code/MET_matching_raob.R
+++ b/R_db_code/MET_matching_raob.R
@@ -33,6 +33,9 @@
 #  V1.5, 2022Apr20, Robert Gilliam: 
 #         - Updated the handling of forecast and the calculation of forecast hour for sub-hourly instances.
 #           Tested forecasting capability during the 2022 ALPACA project using 72 hour WRF forecasts.
+#         - New master Metadata file for surface and upper-air sites was developed for reliable state
+#           and country mapping in stations table for more flexible query & data analysis. Ignored 
+#           if file is not present and backward compatible. $AMETBASE/obs/MET/mastermeta.Rdata
 #
 #######################################################################################################
 #######################################################################################################
@@ -95,6 +98,8 @@
 
   userid         <-system("echo $USER",intern = TRUE)
   projectdate    <-as.POSIXlt(Sys.time(), "GMT")
+
+  mastermeta_file<- paste(amet_base,"/obs/MET/mastermeta.Rdata",sep="")
 
   # Hard Coded settings that do not require user input with RAOB matching option.
   # maxdtmin is set to 60 since soundings take place over an hour. Raob is the only 
@@ -274,7 +279,7 @@ for(t in skipind:nt){
                                  model$projection$lat, model$projection$lon, model$projection$latv, 
                                  model$projection$lonv, model$projection$cells_on_vertex,
                                  cind, cwgt,  mysql$dbase, sitecommand, sitemax, updateSiteTable,
-                                 tmpquery_file=query_file2)
+                                 tmpquery_file=query_file2, mastermeta_file=mastermeta_file)
     sitenum <-site_update$sitenum
     sitelist<-site_update$sitelist
     cind    <-site_update$cind
@@ -284,7 +289,8 @@ for(t in skipind:nt){
     site_update <- wrf_site_map(obs$meta$site, obs$meta$sites_unique, sitelist, sitenum, obs$meta$slat, 
                                 obs$meta$slon, obs$meta$elev, obs$meta$report_type, obs$meta$site_locname, 
                                 model$projection, wrfind, interp, mysql$dbase, sitecommand, sitemax, 
-                                updateSiteTable, buffer=buffer, tmpquery_file=query_file2)
+                                updateSiteTable, buffer=buffer, tmpquery_file=query_file2,
+                                mastermeta_file=mastermeta_file)
     sitenum <-site_update$sitenum
     sitelist<-site_update$sitelist
     wrfind  <-site_update$wrfind

--- a/R_db_code/MET_matching_surface.R
+++ b/R_db_code/MET_matching_surface.R
@@ -36,7 +36,11 @@
 #           in the same project directory.
 #  V1.5, 2022Apr20, Robert Gilliam: 
 #         - Updated the handling of forecast and the calculation of forecast hour for sub-hourly instances.
-#           Tested forecasting capability during the 2022 ALPACA project using 72 hour WRF forecasts.
+#         - Added new master META data file (a R data file in distribution) and code to use if availiable 
+#           to update site state and country fields in stations table. Backward compatible.
+#         - New master Metadata file for surface and upper-air sites was developed for reliable state
+#           and country mapping in stations table for more flexible query & data analysis. Ignored 
+#           if file is not present and backward compatible. $AMETBASE/obs/MET/mastermeta.Rdata
 #
 #######################################################################################################
   options(warn=-1)
@@ -100,6 +104,8 @@
 
   userid         <- system("echo $USER",intern = TRUE)
   projectdate    <- as.POSIXlt(Sys.time(), "GMT")
+
+  mastermeta_file<- paste(amet_base,"/obs/MET/mastermeta.Rdata",sep="")
 
   # MySQL connection information and command to send temporary query file to database.
   # This method is dramatically quicker than sending single queries for each of the
@@ -273,7 +279,7 @@ for(t in skipind:nt){
                                  model$projection$lat, model$projection$lon, model$projection$latv, 
                                  model$projection$lonv, model$projection$cells_on_vertex,
                                  cind, cwgt,  mysql$dbase, sitecommand, sitemax, updateSiteTable,
-                                 tmpquery_file=query_file2)
+                                 tmpquery_file=query_file2, mastermeta_file=mastermeta_file)
     sitenum <-site_update$sitenum
     sitelist<-site_update$sitelist
     cind    <-site_update$cind
@@ -283,7 +289,8 @@ for(t in skipind:nt){
     site_update <- wrf_site_map(obs$meta$site, obs$meta$sites_unique, sitelist, sitenum, obs$meta$slat, 
                                 obs$meta$slon, obs$meta$elev, obs$meta$report_type, obs$meta$site_locname, 
                                 model$projection, wrfind, interp, mysql$dbase, sitecommand, sitemax, 
-                                updateSiteTable, buffer=buffer, tmpquery_file=query_file2)
+                                updateSiteTable, buffer=buffer, tmpquery_file=query_file2,
+                                mastermeta_file=mastermeta_file)
     sitenum <-site_update$sitenum
     sitelist<-site_update$sitelist
     wrfind  <-site_update$wrfind

--- a/scripts_analysis/metExample_mcip/input_files/raob.input
+++ b/scripts_analysis/metExample_mcip/input_files/raob.input
@@ -88,8 +88,12 @@
                 as.numeric(unlist(strsplit(Sys.getenv("AMET_PLIM")," ")))[2])
  layer      <- c(as.numeric(unlist(strsplit(Sys.getenv("AMET_PLAYER")," ")))[1],
                  as.numeric(unlist(strsplit(Sys.getenv("AMET_PLAYER")," ")))[2])
- # Note Extra is for custom extra specs added to query. Must know MySQL
- extra<-"  "
+
+ # Note Extra is for custom extra specs added to query. Must know MySQL. Below are
+ # examples of using US States and Countries (ref: $AMETBASE/obs/MET/metar_codes_country.txt)
+ # usage of LIKE searches country names in database for string enclosed %Country%
+ # WARNING: IF State or Country Criteria are set PROFILE Stats Site should be set to ALL
+ extra      <-Sys.getenv("AMET_EXTRA")
 #########################################################################
 
 #########################################################################

--- a/scripts_analysis/metExample_mcip/input_files/raob.static.input
+++ b/scripts_analysis/metExample_mcip/input_files/raob.static.input
@@ -44,6 +44,14 @@
    extrall <- ""
  }
 #########################################################################
+#-- Extra query criteria -- If empty ignore, if not add to extrall.
+#########################################################################
+ if(!exists("extra") )  { extra <- ""  }
+ extra <- trimws(extra)
+ if(extra!="" & (statid=="ALL" || TSERIESM)) {
+  extrall  <-paste(extrall,extra)
+ }
+#########################################################################
 # Database/Tables/Query Specifications
 #########################################################################
  layervar   <-"plevel"

--- a/scripts_analysis/metExample_mcip/run_daily_barplot.csh
+++ b/scripts_analysis/metExample_mcip/run_daily_barplot.csh
@@ -45,11 +45,16 @@
   # 1. Dates between Jul 1-31, 2011 and only sites *WITHIN* the lat-lon box 23-55 deg and -125-65 deg
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  AND s.lat BETWEEN 23 AND 55 AND \
                          s.lon BETWEEN -125 AND -65 ORDER BY d.ob_date"
+
   # 2. Dates between Jul 1-31, 2011 and only sites *OUTSIDE* the lat-lon box 23-55 deg and -125-65 deg.
   #    This is a nice way to look at MPAS global output outside of the fine mesh over the US as an example.
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  AND s.lat NOT BETWEEN 23 AND 55 AND \
                          s.lon NOT BETWEEN -125 AND -65 ORDER BY d.ob_date"
-  # 3. Use all sites in the entire domain and data from Jul 1-31, 2011
+
+  # 3. Dates between Jul 1-31, 2011 and only sites *WITHIN* the United States (only for AMETv1.5+ matching)
+  setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801 AND s.country LIKE '%United States%' "
+
+  # 4. Use all sites in the entire domain and data from Jul 1-31, 2011
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  ORDER BY d.ob_date"
   #-----------------------------------------------------------------------------------------------------------------------
 

--- a/scripts_analysis/metExample_mcip/run_raob.csh
+++ b/scripts_analysis/metExample_mcip/run_raob.csh
@@ -11,6 +11,8 @@
 #
 # Apr 2022: Added a loop for single time native profiles. The script now
 #           runs this script for each 00/12 UTC time over date range provided
+# May 2022: Added extra option for Timeseries and Profile stats options for 
+#           additional criteria like state and country.
 # -----------------------------------------------------------------------
 ####################################################################################
 #                          USER CONFIGURATION OPTIONS
@@ -26,8 +28,6 @@
   # MySQL database server connection and AMET database
   setenv AMET_DATABASE  user_database
   setenv MYSQL_SERVER   mysql.server.gov
-  setenv AMET_DATABASE  amad_nrt
-  setenv MYSQL_SERVER   amet.ib
 
   #  AMET project id or simulation id
   setenv AMET_PROJECT metExample_mcip 
@@ -72,8 +72,8 @@
   #  Observation site ID array. 
   #  "ALL" will get data for all sites, but only applicable for RAOB_PROFILEM option
   #  AMET_GROUPSITES allows grouping (or not) of defined site IDs for RAOB_PROFILEM option
-  set SITES=(ALL)
   set SITES=(KGSO KMHX)
+  set SITES=(ALL)
 
   # Should SITES be grouped or averaged (T/F). Grouped sites only work for 
   # profile statistics on mandatory pressure levels via RAOB_PROFILEM T
@@ -92,6 +92,16 @@
   # spatial plots will only cover the area below.
   setenv AMET_BOUNDS_LAT "23 55"
   setenv AMET_BOUNDS_LON "-135 -60"
+
+  # Note Extra is for custom extra specs added to query. Must know MySQL. Below are
+  # examples of using US States and Countries (ref: $AMETBASE/obs/MET/metar_codes_country.txt)
+  # usage of LIKE searches country names in database for string enclosed %Country%
+  # WARNING: IF State or Country Criteria are set for RAOB_PROFILEM, User should set SITES=(ALL)
+  # WARNING: Can result in no data if done incorrectly. Examine query for sensibility 
+  setenv AMET_EXTRA "AND (s.state='NC' OR s.state='GA' OR s.state='FL' OR s.state='VA' OR s.state='SC')"
+  setenv AMET_EXTRA "AND (s.state!='UT' AND s.state!='NV' AND s.state!='CO' AND s.state!='NM' AND s.state!='AZ')"
+  setenv AMET_EXTRA "AND (s.country LIKE '%Mexico%' OR s.country LIKE '%Canada%')"
+  setenv AMET_EXTRA "AND (s.country NOT LIKE '%United States%')"
 
   # Do you want a CVS files with Spatial and Daily Statistics?
   setenv AMET_TEXTSTATS T

--- a/scripts_analysis/metExample_mcip/run_summary.csh
+++ b/scripts_analysis/metExample_mcip/run_summary.csh
@@ -38,15 +38,22 @@
   # This variable (AMET_CRITERIA) controls what data you want to evaluate. It is necessary to understand how to build
   # MySQL queries to develop your own custom queries of data. Below are some examples along with what criteria can be used.
   # Below is the MySQL query that defines the data to be extracted for analysis.
-  # Note:   sample queries: 1) By day range only 2) date range and state 
-  #                         3) date range and observation network and 4) Date range full domain
+  # Note:   sample queries: 1) date range and observation network 2) date range and state 
+  #                         3) date range an country see $AMET1/obs/MET/metar_codes_country.txt for countries
+  #                         4) date range and lat-lon bounds and 5) Date range full domain
   # There are unlimted number of combinations not shown like query by Temperature, wind speed ranges, lat-lon bounds, etc
-  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 and (s.ob_network='OTHER-MTR' \
-                         or s.ob_network='SAO' or s.ob_network='ASOS' or s.ob_network='MARITIME')"
+  # 1)
+  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 and (s.ob_network='METAR' \
+                         or s.ob_network='MARITIME')"
+  # 2)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND d.ob_time AND (s.state='FL' \
                          OR s.state='SC' OR s.state='GA' OR s.state='LA' OR s.state='MS' OR s.state='AL' OR s.state='NC') "
+  # 3)
+  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND d.ob_time AND s.country LIKE '%United States%' "
+  # 4)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND (s.lat BETWEEN \
                          38 and 40 AND s.lon BETWEEN -77.8 and -75.0)"
+  # 5)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801"
 
   #  Plot Type, plot options are "png" or "pdf" are only plot formats unless user modifies

--- a/scripts_analysis/metExample_mpas/input_files/raob.input
+++ b/scripts_analysis/metExample_mpas/input_files/raob.input
@@ -88,8 +88,12 @@
                 as.numeric(unlist(strsplit(Sys.getenv("AMET_PLIM")," ")))[2])
  layer      <- c(as.numeric(unlist(strsplit(Sys.getenv("AMET_PLAYER")," ")))[1],
                  as.numeric(unlist(strsplit(Sys.getenv("AMET_PLAYER")," ")))[2])
- # Note Extra is for custom extra specs added to query. Must know MySQL
- extra<-"  "
+
+ # Note Extra is for custom extra specs added to query. Must know MySQL. Below are
+ # examples of using US States and Countries (ref: $AMETBASE/obs/MET/metar_codes_country.txt)
+ # usage of LIKE searches country names in database for string enclosed %Country%
+ # WARNING: IF State or Country Criteria are set PROFILE Stats Site should be set to ALL
+ extra      <-Sys.getenv("AMET_EXTRA")
 #########################################################################
 
 #########################################################################

--- a/scripts_analysis/metExample_mpas/input_files/raob.static.input
+++ b/scripts_analysis/metExample_mpas/input_files/raob.static.input
@@ -44,6 +44,14 @@
    extrall <- ""
  }
 #########################################################################
+#-- Extra query criteria -- If empty ignore, if not add to extrall.
+#########################################################################
+ if(!exists("extra") )  { extra <- ""  }
+ extra <- trimws(extra)
+ if(extra!="" & (statid=="ALL" || TSERIESM)) {
+  extrall  <-paste(extrall,extra)
+ }
+#########################################################################
 # Database/Tables/Query Specifications
 #########################################################################
  layervar   <-"plevel"

--- a/scripts_analysis/metExample_mpas/run_daily_barplot.csh
+++ b/scripts_analysis/metExample_mpas/run_daily_barplot.csh
@@ -45,11 +45,16 @@
   # 1. Dates between Jul 1-31, 2011 and only sites *WITHIN* the lat-lon box 23-55 deg and -125-65 deg
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  AND s.lat BETWEEN 23 AND 55 AND \
                          s.lon BETWEEN -125 AND -65 ORDER BY d.ob_date"
+
   # 2. Dates between Jul 1-31, 2011 and only sites *OUTSIDE* the lat-lon box 23-55 deg and -125-65 deg.
   #    This is a nice way to look at MPAS global output outside of the fine mesh over the US as an example.
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  AND s.lat NOT BETWEEN 23 AND 55 AND \
                          s.lon NOT BETWEEN -125 AND -65 ORDER BY d.ob_date"
-  # 3. Use all sites in the entire domain and data from Jul 1-31, 2011
+
+  # 3. Dates between Jul 1-31, 2011 and only sites *WITHIN* the United States (only for AMETv1.5+ matching)
+  setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801 AND s.country LIKE '%United States%' "
+
+  # 4. Use all sites in the entire domain and data from Jul 1-31, 2011
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  ORDER BY d.ob_date"
   #-----------------------------------------------------------------------------------------------------------------------
 

--- a/scripts_analysis/metExample_mpas/run_raob.csh
+++ b/scripts_analysis/metExample_mpas/run_raob.csh
@@ -11,6 +11,8 @@
 #
 # Apr 2022: Added a loop for single time native profiles. The script now
 #           runs this script for each 00/12 UTC time over date range provided
+# May 2022: Added extra option for Timeseries and Profile stats options for 
+#           additional criteria like state and country.
 # -----------------------------------------------------------------------
 ####################################################################################
 #                          USER CONFIGURATION OPTIONS
@@ -26,8 +28,6 @@
   # MySQL database server connection and AMET database
   setenv AMET_DATABASE  user_database
   setenv MYSQL_SERVER   mysql.server.gov
-  setenv AMET_DATABASE  amad_nrt
-  setenv MYSQL_SERVER   amet.ib
 
   #  AMET project id or simulation id
   setenv AMET_PROJECT metExample_mpas 
@@ -72,8 +72,8 @@
   #  Observation site ID array. 
   #  "ALL" will get data for all sites, but only applicable for RAOB_PROFILEM option
   #  AMET_GROUPSITES allows grouping (or not) of defined site IDs for RAOB_PROFILEM option
-  set SITES=(ALL)
   set SITES=(KGSO KMHX)
+  set SITES=(ALL)
 
   # Should SITES be grouped or averaged (T/F). Grouped sites only work for 
   # profile statistics on mandatory pressure levels via RAOB_PROFILEM T
@@ -92,6 +92,16 @@
   # spatial plots will only cover the area below.
   setenv AMET_BOUNDS_LAT "23 55"
   setenv AMET_BOUNDS_LON "-135 -60"
+
+  # Note Extra is for custom extra specs added to query. Must know MySQL. Below are
+  # examples of using US States and Countries (ref: $AMETBASE/obs/MET/metar_codes_country.txt)
+  # usage of LIKE searches country names in database for string enclosed %Country%
+  # WARNING: IF State or Country Criteria are set for RAOB_PROFILEM, User should set SITES=(ALL) 
+  # WARNING: Can result in no data if done incorrectly. Examine query for sensibility 
+  setenv AMET_EXTRA "AND (s.state='NC' OR s.state='GA' OR s.state='FL' OR s.state='VA' OR s.state='SC')"
+  setenv AMET_EXTRA "AND (s.state!='UT' AND s.state!='NV' AND s.state!='CO' AND s.state!='NM' AND s.state!='AZ')"
+  setenv AMET_EXTRA "AND (s.country LIKE '%Mexico%' OR s.country LIKE '%Canada%')"
+  setenv AMET_EXTRA "AND (s.country NOT LIKE '%United States%')"
 
   # Do you want a CVS files with Spatial and Daily Statistics?
   setenv AMET_TEXTSTATS T

--- a/scripts_analysis/metExample_mpas/run_summary.csh
+++ b/scripts_analysis/metExample_mpas/run_summary.csh
@@ -38,15 +38,22 @@
   # This variable (AMET_CRITERIA) controls what data you want to evaluate. It is necessary to understand how to build
   # MySQL queries to develop your own custom queries of data. Below are some examples along with what criteria can be used.
   # Below is the MySQL query that defines the data to be extracted for analysis.
-  # Note:   sample queries: 1) By day range only 2) date range and state 
-  #                         3) date range and observation network and 4) Date range full domain
+  # Note:   sample queries: 1) date range and observation network 2) date range and state 
+  #                         3) date range an country see $AMET1/obs/MET/metar_codes_country.txt for countries
+  #                         4) date range and lat-lon bounds and 5) Date range full domain
   # There are unlimted number of combinations not shown like query by Temperature, wind speed ranges, lat-lon bounds, etc
-  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 and (s.ob_network='OTHER-MTR' \
-                         or s.ob_network='SAO' or s.ob_network='ASOS' or s.ob_network='MARITIME')"
+  # 1)
+  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 and (s.ob_network='METAR' \
+                         or s.ob_network='MARITIME')"
+  # 2)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND d.ob_time AND (s.state='FL' \
                          OR s.state='SC' OR s.state='GA' OR s.state='LA' OR s.state='MS' OR s.state='AL' OR s.state='NC') "
+  # 3)
+  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND d.ob_time AND s.country LIKE '%United States%' "
+  # 4)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND (s.lat BETWEEN \
                          38 and 40 AND s.lon BETWEEN -77.8 and -75.0)"
+  # 5)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801"
 
   #  Plot Type, plot options are "png" or "pdf" are only plot formats unless user modifies

--- a/scripts_analysis/metExample_wrf/input_files/raob.input
+++ b/scripts_analysis/metExample_wrf/input_files/raob.input
@@ -88,8 +88,12 @@
                 as.numeric(unlist(strsplit(Sys.getenv("AMET_PLIM")," ")))[2])
  layer      <- c(as.numeric(unlist(strsplit(Sys.getenv("AMET_PLAYER")," ")))[1],
                  as.numeric(unlist(strsplit(Sys.getenv("AMET_PLAYER")," ")))[2])
- # Note Extra is for custom extra specs added to query. Must know MySQL
- extra<-"  "
+
+ # Note Extra is for custom extra specs added to query. Must know MySQL. Below are
+ # examples of using US States and Countries (ref: $AMETBASE/obs/MET/metar_codes_country.txt)
+ # usage of LIKE searches country names in database for string enclosed %Country%
+ # WARNING: IF State or Country Criteria are set PROFILE Stats Site should be set to ALL
+ extra      <-Sys.getenv("AMET_EXTRA")
 #########################################################################
 
 #########################################################################

--- a/scripts_analysis/metExample_wrf/input_files/raob.static.input
+++ b/scripts_analysis/metExample_wrf/input_files/raob.static.input
@@ -44,6 +44,14 @@
    extrall <- ""
  }
 #########################################################################
+#-- Extra query criteria -- If empty ignore, if not add to extrall.
+#########################################################################
+ if(!exists("extra") )  { extra <- ""  }
+ extra <- trimws(extra)
+ if(extra!="" & (statid=="ALL" || TSERIESM)) {
+  extrall  <-paste(extrall,extra)
+ }
+#########################################################################
 # Database/Tables/Query Specifications
 #########################################################################
  layervar   <-"plevel"

--- a/scripts_analysis/metExample_wrf/run_daily_barplot.csh
+++ b/scripts_analysis/metExample_wrf/run_daily_barplot.csh
@@ -45,11 +45,16 @@
   # 1. Dates between Jul 1-31, 2011 and only sites *WITHIN* the lat-lon box 23-55 deg and -125-65 deg
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  AND s.lat BETWEEN 23 AND 55 AND \
                          s.lon BETWEEN -125 AND -65 ORDER BY d.ob_date"
+
   # 2. Dates between Jul 1-31, 2011 and only sites *OUTSIDE* the lat-lon box 23-55 deg and -125-65 deg.
   #    This is a nice way to look at MPAS global output outside of the fine mesh over the US as an example.
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  AND s.lat NOT BETWEEN 23 AND 55 AND \
                          s.lon NOT BETWEEN -125 AND -65 ORDER BY d.ob_date"
-  # 3. Use all sites in the entire domain and data from Jul 1-31, 2011
+
+  # 3. Dates between Jul 1-31, 2011 and only sites *WITHIN* the United States (only for AMETv1.5+ matching)
+  setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801 AND s.country LIKE '%United States%' "
+
+  # 4. Use all sites in the entire domain and data from Jul 1-31, 2011
   setenv AMET_CRITERIA  "AND d.ob_date >=  20160701 AND d.ob_date < 20160801  ORDER BY d.ob_date"
   #-----------------------------------------------------------------------------------------------------------------------
 

--- a/scripts_analysis/metExample_wrf/run_raob.csh
+++ b/scripts_analysis/metExample_wrf/run_raob.csh
@@ -11,6 +11,8 @@
 #
 # Apr 2022: Added a loop for single time native profiles. The script now
 #           runs this script for each 00/12 UTC time over date range provided
+# May 2022: Added extra option for Timeseries and Profile stats options for 
+#           additional criteria like state and country.
 # -----------------------------------------------------------------------
 ####################################################################################
 #                          USER CONFIGURATION OPTIONS
@@ -26,8 +28,6 @@
   # MySQL database server connection and AMET database
   setenv AMET_DATABASE  user_database
   setenv MYSQL_SERVER   mysql.server.gov
-  setenv AMET_DATABASE  amad_nrt
-  setenv MYSQL_SERVER   amet.ib
 
   #  AMET project id or simulation id
   setenv AMET_PROJECT metExample_wrf 
@@ -72,8 +72,8 @@
   #  Observation site ID array. 
   #  "ALL" will get data for all sites, but only applicable for RAOB_PROFILEM option
   #  AMET_GROUPSITES allows grouping (or not) of defined site IDs for RAOB_PROFILEM option
-  set SITES=(ALL)
   set SITES=(KGSO KMHX)
+  set SITES=(ALL)
 
   # Should SITES be grouped or averaged (T/F). Grouped sites only work for 
   # profile statistics on mandatory pressure levels via RAOB_PROFILEM T
@@ -92,6 +92,16 @@
   # spatial plots will only cover the area below.
   setenv AMET_BOUNDS_LAT "23 55"
   setenv AMET_BOUNDS_LON "-135 -60"
+
+  # Note Extra is for custom extra specs added to query. Must know MySQL. Below are
+  # examples of using US States and Countries (ref: $AMETBASE/obs/MET/metar_codes_country.txt)
+  # usage of LIKE searches country names in database for string enclosed %Country%
+  # WARNING: IF State or Country Criteria are set for RAOB_PROFILEM, User should set SITES=(ALL) 
+  # WARNING: Can result in no data if done incorrectly. Examine query for sensibility 
+  setenv AMET_EXTRA "AND (s.state='NC' OR s.state='GA' OR s.state='FL' OR s.state='VA' OR s.state='SC')"
+  setenv AMET_EXTRA "AND (s.state!='UT' AND s.state!='NV' AND s.state!='CO' AND s.state!='NM' AND s.state!='AZ')"
+  setenv AMET_EXTRA "AND (s.country LIKE '%Mexico%' OR s.country LIKE '%Canada%')"
+  setenv AMET_EXTRA "AND (s.country NOT LIKE '%United States%')"
 
   # Do you want a CVS files with Spatial and Daily Statistics?
   setenv AMET_TEXTSTATS T

--- a/scripts_analysis/metExample_wrf/run_summary.csh
+++ b/scripts_analysis/metExample_wrf/run_summary.csh
@@ -38,15 +38,22 @@
   # This variable (AMET_CRITERIA) controls what data you want to evaluate. It is necessary to understand how to build
   # MySQL queries to develop your own custom queries of data. Below are some examples along with what criteria can be used.
   # Below is the MySQL query that defines the data to be extracted for analysis.
-  # Note:   sample queries: 1) By day range only 2) date range and state 
-  #                         3) date range and observation network and 4) Date range full domain
+  # Note:   sample queries: 1) date range and observation network 2) date range and state 
+  #                         3) date range an country see $AMET1/obs/MET/metar_codes_country.txt for countries
+  #                         4) date range and lat-lon bounds and 5) Date range full domain
   # There are unlimted number of combinations not shown like query by Temperature, wind speed ranges, lat-lon bounds, etc
-  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 and (s.ob_network='OTHER-MTR' \
-                         or s.ob_network='SAO' or s.ob_network='ASOS' or s.ob_network='MARITIME')"
+  # 1)
+  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 and (s.ob_network='METAR' \
+                         or s.ob_network='MARITIME')"
+  # 2)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND d.ob_time AND (s.state='FL' \
                          OR s.state='SC' OR s.state='GA' OR s.state='LA' OR s.state='MS' OR s.state='AL' OR s.state='NC') "
+  # 3)
+  setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND d.ob_time AND s.country LIKE '%United States%' "
+  # 4)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801 AND (s.lat BETWEEN \
                          38 and 40 AND s.lon BETWEEN -77.8 and -75.0)"
+  # 5)
   setenv AMET_CRITERIA  "AND d.ob_date BETWEEN 20160701 AND 20160801"
 
   #  Plot Type, plot options are "png" or "pdf" are only plot formats unless user modifies


### PR DESCRIPTION
Updated model-obs matching of surface and raob sites with state and country metadata in the stations table.

Old method use to work for US states, but MADIS changed it's file metadata. We used offline processing to develop a master metadata R datafile to map sites during the matching process with their respective US state and/or Country. This works for most standard METAR surface and RAOB sites globally. 

Analysis code was updated with examples of the state and country query techniques. And run_raob.csh and config files were updated so profile and timeseries statistics can take advantage of the data with more refined queries.