### PR TITLE
Update MCIP matching scripts updated with better functionality

### DIFF
--- a/scripts_db/metExample_mcip/loop_over_days.csh
+++ b/scripts_db/metExample_mcip/loop_over_days.csh
@@ -2,15 +2,14 @@
 #############################################################
 # Main run config setttings: date start/end, WRF exe, RunID,
 #                            relevant dirs
-set begday       = 20201018
-set endday       = 20201029
+setenv AMETBASE   /home/user/AMET
 
-setenv METTMPDIRX /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/TMP
+set begday       = 20160701
+set endday       = 20160731
 
 #############################################################
-set sfcscript   = /home/grc/AMET_v13/scripts_db/mcip_12us1/matching_surface.csh
-set bsrnscript   = /home/grc/AMET_v13/scripts_db/mcip_12us1/matching_bsrn.csh
-set raobscript   = /home/grc/AMET_v13/scripts_db/mcip_12us1/matching_raob.csh
+set sfcscript   = $AMETBASE/scripts_db/metExample_mcip/matching_surface.csh
+set raobscript  = $AMETBASE/scripts_db/metExample_mcip/matching_raob.csh
 #############################################################
 
 
@@ -25,20 +24,23 @@ while ( $date <= $endday )
   setenv MMS   `echo $date |cut -b5-6`
   setenv DDS   `echo $date |cut -b7-8`
 
-  setenv GRIDCROX /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/GRIDCRO2D
-  setenv METCRO2DX  /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/METCRO2D_${date}.nc4
-  setenv METCRO3DX  /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/METCRO3D_${date}.nc4
-  setenv METDOT3DX  /work/MOD3DEV/grc/NRT_WRF_CMAQ/model_outputs/12us/mcip/EPA_MCIP/METDOT3D_${date}.nc4
+  setenv METTMPDIRX $AMETBASE/model_data/MET/metExample_mcip/TMP
+  setenv GRIDCROX   $AMETBASE/model_data/MET/metExample_mcip/GRIDCRO2D
+  setenv METCRO2DX  $AMETBASE/model_data/MET/metExample_mcip/METCRO2D_${YYS}${MMS}${DDS}.nc
+  setenv METCRO3DX  $AMETBASE/model_data/MET/metExample_mcip/METCRO3D_${YYS}${MMS}${DDS}.nc
+  setenv METDOT3DX  $AMETBASE/model_data/MET/metExample_mcip/METDOT3D_${YYS}${MMS}${DDS}.nc
 
   echo $date
 
-  echo "Running AMET radiation matching"
-   $bsrnscript
-  echo "Running AMET surface matching"
-   $sfcscript
-  echo "Running AMET raob matching"
-   $raobscript
-  
+  echo "Running AMET upper-air met matching"
+  $raobscript
+ 
+  ## SURFACE MET disabled below. To enable daily surface met matching the $sfcscript needs
+  ## this line modified for correct METOUTPUT setting passed into the script:
+  ##  setenv METOUTPUT ${METCRO2DX}
+  #echo "Running AMET surface met matching"
+  #$sfcscript
+ 
  ###########################################################
  # Advance day +1
  set date = `date -d "$date 1 days" '+%Y%m%d' `

--- a/scripts_db/metExample_mcip/matching_radiation.csh
+++ b/scripts_db/metExample_mcip/matching_radiation.csh
@@ -11,9 +11,9 @@ setenv AMET_DATABASE user_database
 setenv MYSQL_SERVER  mysql.server.gov
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
 
-# Root directory of BSRN/SURFRAD obs (same as MADIS). Note that this directory should
-# contain a subdirectory "bsrn" where this radiation obs dataset (unzipped)
-# BSRN/SURFRAD directory configuration: $MADISBASE/bsrn 
+# Root directory of MADIS NetCDF obs. Note that this directory should
+# contain subdirectories like this in the standard
+# MADIS directory configuration: $AMETBASE/point/metar/netcdf
 setenv MADISBASE $AMETBASE/obs/MET
 
 # A unique AMETPROJECT name for the simulation to evaluated. 
@@ -35,6 +35,7 @@ setenv FORECAST F
 # same directory. AMET will look for a GRIDCRO2D file name GRIDCRO2D for grid information only,
 # no time information, so a single file is used for all METCRO2D files.
  setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/METCRO2D
+
 
 # Radiation dataset to match with MPAS, WRF or MCIP -- Only shortwave radiation enabled
 # Options: "bsrn" or "srad"

--- a/scripts_db/metExample_mcip/matching_raob.csh
+++ b/scripts_db/metExample_mcip/matching_raob.csh
@@ -35,12 +35,24 @@ setenv FORECAST F
 # A temporary directory is created. The MCIP files are linked into this temp directory
 # using these generic names using extra RAOB specific scripting towards the end of this
 # csh wrapper. This works for one set of MCIP. If one has mutiple sets of MCIP a wrapper
-# looping script is provided as an example in this same directory where you can loop over
-# days for example and pass those specs into this script and run within this loop.
+# looping script is provided loop_over_days.csh pass those specs into this script.
+# Logic below checks to see if this script should run just one or via looper. 
 setenv METTMPDIR $AMETBASE/model_data/MET/$AMET_PROJECT/TMP
-setenv GRIDCRO   $AMETBASE/model_data/MET/$AMET_PROJECT/GRIDCRO2D_20160701.nc4
-setenv METCRO    $AMETBASE/model_data/MET/$AMET_PROJECT/METCRO3D_20160701.nc4
-setenv METDOT    $AMETBASE/model_data/MET/$AMET_PROJECT/METDOT3D_20160701.nc4
+
+# Single Day Example
+setenv GRIDCRO   $AMETBASE/model_data/MET/$AMET_PROJECT/GRIDCRO2D
+setenv METCRO    $AMETBASE/model_data/MET/$AMET_PROJECT/METCRO3D_160701.nc
+setenv METDOT    $AMETBASE/model_data/MET/$AMET_PROJECT/METDOT3D_160701.nc
+
+# Logic to check for case where MCIP files are being passed by loop_over_day.csh wrapper
+if ( ! $?METCRO3DX || ! $?METDOT3DX || ! $?GRIDCRO) then
+   echo "Script not set in daily run mode. Will run matching for a single day. "
+else
+   echo "METCRO3D and METDOT3D files are being passed into script via loop_over_days.csh"
+   setenv GRIDCRO   $GRIDCROX
+   setenv METCRO    $METCRO3DX
+   setenv METDOT    $METDOT3DX
+endif
 
 # Matching Mode options.
 # Native level matching   : Store full Rawindsonde profile and model profile on their native levels.

--- a/scripts_db/metExample_mcip/matching_surface.csh
+++ b/scripts_db/metExample_mcip/matching_surface.csh
@@ -36,6 +36,10 @@ setenv FORECAST F
 # no time information, so a single file is used for all METCRO2D files.
  setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/METCRO2D
 
+ # Uncomment to run this script via loop_over_days.csh wrapper example.
+ #setenv METOUTPUT ${METCRO2DX}
+
+
 # MADIS dataset to match with MPAS, WRF or MCIP
 # Options: metar, maritime, sao, mesonet, or text for non-MADIS obs input
 # Note: user must have these files downloaded in a MADIS defined directory structure.


### PR DESCRIPTION
Updated loop_over_days.csh with focus on running matching_raob.csh, but option/example to run matching_surface.csh.

Updated matching_raob.csh to work for a daily matching example if not ran from loop wrapper. But will run via loop_over_days.csh if the environmental variables needed are set.

Updated matching_surface.csh with commented out option to run via loop_over_days.csh.

Tested all modes of operation.