### PR TITLE
Precip analysis update leveraging PRISM BIL data

### DIFF
--- a/R_analysis_code/MET_prism_precip.R
+++ b/R_analysis_code/MET_prism_precip.R
@@ -21,20 +21,33 @@
 #    is the only granularity with this script currently. Users will have to take the NetCDF files from those
 #    comparisons to do evaluations of weekly, seasonaly or annual precipitation.
 #	
-#-----------------------------------------------------------------------#####################################
+#  - Version 1.5, Jul 6, 2022, Robert Gilliam                             
+#       - Major update! OSU/PRISM Group ended ASCII data distribution. 
+#         Added the PRISM BIL raster data cabability to replace ASCII.
+#         Old ASCII is still operable, but BIL is much simpler and enables Leaflet HTML plot output.
+#         Added specific functionality for daily, monthly or annual comparisons. Monthly default.
+#         BIL (Raster data) format is the only workable option if user does not have ASCII archived.
+#         Update also adds better screen prints of operation and stats + test stats output file.
+#         Cool new Leaflet plots are configurable using color and level settings via wrapper.
+#         The run_prism_comp.csh wrapper is updated for single anal or looping over days/months/years.
+#   
+#-----------------------------------------------------------------------#
+#########################################################################
   options(warn=-1)
+
 #############################################################################################################
-  require(ncdf4)
-  require(maps)
-  require(mapdata)
-  require(akima)
-  require(fields)
+  if(!require(ncdf4))      {stop("Required Package NCDF4 was not loaded")}
+  if(!require(prism))      {stop("Required Package prism was not loaded")}
+  if(!require(raster))     {stop("Required Package raster was not loaded")}
+  if(!require(leaflet))    {stop("Required Package leaflet was not loaded")}
+  if(!require(htmlwidgets)){stop("Required Package htmlwidgets was not loaded")}
 
- ametbase         <- Sys.getenv("AMETBASE")
- ametR            <- paste(ametbase,"/R_analysis_code",sep="")
- source (paste(ametR,"/MET_amet.prism-lib.R",sep=""))
+  ametbase       <- Sys.getenv("AMETBASE")
+  ametR          <- paste(ametbase,"/R_analysis_code",sep="")
+  source (paste(ametR,"/MET_amet.prism-lib.R",sep=""))
 
 
+  project        <-Sys.getenv("AMET_PROJECT")
   model          <-Sys.getenv("MODEL")
   model_start    <-Sys.getenv("MODEL_START")
   model_end      <-Sys.getenv("MODEL_END")
@@ -43,14 +56,32 @@
   precip_outfile <-Sys.getenv("OUTFILE")
 
   daily          <-as.logical(Sys.getenv("DAILY"))
+  annual         <-as.logical(Sys.getenv("ANNUAL"))
 
   prismdir       <-Sys.getenv("PRISM_DIR") 
   prism_prefix   <-Sys.getenv("PRISM_PREFIX") 
+  bil            <-as.logical(Sys.getenv("PRISM_BIL")) 
+
+  leaf_dxdykm    <-as.numeric(Sys.getenv("LEAF_DXDYKM"))
+  pbins          <-as.numeric(unlist(strsplit(Sys.getenv("LEAF_LEVELS")," ")))
+  pdbins         <-as.numeric(unlist(strsplit(Sys.getenv("LEAF_DLEVELS")," ")))
+  cols1          <-unlist(strsplit(Sys.getenv("LEAF_COLOR")," "))
+  dcols1         <-unlist(strsplit(Sys.getenv("LEAF_DCOLOR")," "))
+
+  # Backward compatability for old wrapper before BIL data option
+  if(bil == ""         || is.na(bil) )          { bil    <- FALSE  }
+  if(annual == ""      || is.na(annual) )       { annual <- FALSE  }
+  if(leaf_dxdykm == "" || is.na(leaf_dxdykm) )  { leaf_dxdykm <- -99  }
 
  ###############################################################################################
  ###############################################################################################
  #
  # Open one of the model outputs and grab model name information
+ writeLines(paste("            "))
+ writeLines(paste("     ------------------------------------------------------       "))
+ writeLines(paste("     Reading PRISM and Model Output & Regrid For Comparison       "))
+ writeLines(paste("     ------------------------------------------------------       "))
+ writeLines(paste("            "))
   f1  <-nc_open(model_start)
    head    <- ncatt_get(f1, varid=0, attname="TITLE" )$value
    model   <- ncatt_get(f1, varid=0, attname="model_name" )$value
@@ -69,12 +100,17 @@
   }
   nc_close(f1)
 
+ ###################################################################################
+ # Main Processing 1. Aquire and read PRISM, Read model precip and interpolate PRISM to model grid
   # Read prism file and get grid information and monthly precip total on prism grid.
   # List contains:
-  # grid        <-list(lat=lat, lon=lon, dxdykm=dxdykm, nx=nx, ny=ny)
-  # precip
-  prism <- prism_read(model_start_date, prismdir, prism_prefix, daily=daily)
-  
+  # prism$grid        <-list(lat=lat, lon=lon, dxdykm=dxdykm, nx=nx, ny=ny)
+  # prism$precip
+  if(bil) {
+    prism <- prism_read_bil(model_start_date, prismdir, daily=daily, annual=annual)
+  } else {
+    prism <- prism_read(model_start_date, prismdir, prism_prefix, daily=F)
+  }
 
  if(model == "mpas") {
   # Get mpas precip at the start and end of the period
@@ -88,7 +124,9 @@
   prism.na.mask     <- ifelse(is.na(prism_precip_mm), 0, 1)
   model_precip_mm   <- model_precip_mm * prism.na.mask
   prism_precip_mm   <- ifelse(is.na(prism_precip_mm), 0, prism_precip_mm)
+  dxdykm            <- ifelse(leaf_dxdykm == -99, round(min(modelp1$grid$carea)), leaf_dxdykm)
  }
+
  if(model == "wrf") {
   modelp1 <-wrf_precip(model_start, tindex=start_tindex)   
   modelp2 <-wrf_precip(model_end, tindex=end_tindex)   
@@ -99,15 +137,155 @@
   prism.na.mask     <- ifelse(is.na(prism_precip_mm), 0, 1)
   model_precip_mm   <- model_precip_mm * prism.na.mask
   prism_precip_mm   <- ifelse(is.na(prism_precip_mm), 0, prism_precip_mm)
-
+  dxdykm            <- ifelse(leaf_dxdykm == -99, modelp1$grid$dx/1000, leaf_dxdykm)
  }
+ ###################################################################################
   
+ ###################################################################################
+ # Write Model and PRISM grids on model domain to NetCDF output
+ writeLines(paste("            "))
+ writeLines(paste("     -------------------------------------------------------       "))
+ writeLines(paste("     Creating NetCDF Output For External Plotting & Analysis       "))
+ writeLines(paste("     -------------------------------------------------------       "))
+ writeLines(paste("            "))
  f1  <-nc_open(precip_outfile,write=T)
    writeLines(paste("See model output:",precip_outfile))
    ncvar_put(f1,varid="PRISM_PRECIP_MM",prism_precip_mm)
    ncvar_put(f1,varid="MODEL_PRECIP_MM",model_precip_mm)
  nc_close(f1)
+ writeLines(paste("            "))
+ ###################################################################################
 
+ ###################################################################################
+ # Compute grid statisitcs for land cells in full WRF/MPAS domain (CONUS only)
+ # Print to std output & write text file.
+ prism_total_masked<-ifelse(prism_precip_mm == 0,NA, prism_precip_mm)
+ model_total_masked<-ifelse(prism_precip_mm == 0,NA, model_precip_mm)
+ if(sum(prism_precip_mm,na.rm=T)==0) {
+   psmessage <- "   ---- No Precipitation reported for this period ---- "
+   diff      <- 0
+   bias.grid <- 0
+   mea.grid  <- 0
+   cor.grid  <- 1
+ } else {
+   psmessage <- "   "
+   diff      <- model_total_masked- prism_total_masked
+   bias.grid <-sprintf("%5.3f", mean(diff,na.rm=T))
+   mea.grid  <-sprintf("%5.3f",mean(abs(diff),na.rm=T))
+   cor.grid  <-sprintf("%5.3f",cor(matrix(model_total_masked),matrix(prism_total_masked),use='complete.obs'))
+ }
+ # Chop up full path and name of NetCDF file to get directory for text stats file & write stats to text
+ parts    <-unlist(strsplit(model_start_date,split="_"))
+ start_day<-parts[1]
+ parts    <-unlist(strsplit(precip_outfile,split="/"))
+ nparts   <-length(parts)
+ outdir   <-paste(parts[2:nparts-1],sep="/",collapse="/")
+ period   <-"monthly"
+ if(daily)  { period  <-"daily"  }
+ if(annual) { period  <-"annual" }
+
+ # Print statistics to screen
+ writeLines(paste("     -----------------------------------------       "))
+ writeLines(paste("     Computing Grid Statistics & Write to Text       "))
+ writeLines(paste("     -----------------------------------------       "))
+ writeLines(paste(psmessage))
+ writeLines(paste("Period and start day:",period," ",start_day))
+ writeLines(paste("Grid Mean Error -- Bias (mm):",bias.grid))  
+ writeLines(paste("Grid Mean Absolute Error (mm):",mea.grid))  
+ writeLines(paste("Grid Correlation:",cor.grid))
+ writeLines(paste("Note that model and obs gridpoint are set to missing for all no-precip obs cells."))
+
+ txtstatf <- paste("/",outdir,"/",project,".prism.",period,".",start_day,".txt",sep="")
+ writeLines(paste("Text stats are preserved in this text output:",txtstatf))
+ sfile    <-file(txtstatf,"w")
+ writeLines(paste("Period and start day:",period," ",start_day), con=sfile)
+ writeLines(paste("Grid Mean Error -- Bias (mm):",bias.grid), con =sfile)  
+ writeLines(paste("Grid Mean Absolute Error (mm):",mea.grid), con =sfile)  
+ writeLines(paste("Grid Correlation:",cor.grid), con =sfile)
+ writeLines(paste("Note that model and obs gridpoint are set to missing for all no-precip obs cells."), con =sfile)
+ close(sfile)
+ writeLines(paste("            "))
+ ###################################################################################
+
+ ###################################################################################
+ # Leaflet HTML Output option
+ if(bil) {
+  writeLines(paste("     -----------------------------------------------       "))
+  writeLines(paste("     Creating Leaflet HTML Outputs for Visualization       "))
+  writeLines(paste("     -----------------------------------------------       "))
+  writeLines(paste("            "))
+  leaffile <- paste("/",outdir,"/",project,".prism.leaf.",period,".",start_day,".html",sep="")
+  regrid_ll<-regrid2d_to_latlon(model_precip_mm, modelp1$grid$lat, modelp1$grid$lon,
+                               grid_data2=prism_precip_mm, dxdykm=dxdykm, model=model)
+
+  rlon     <- range(regrid_ll$grid$lon)
+  rlat     <- range(regrid_ll$grid$lat)
+  xy       <- cbind(as.vector(modelp1$grid$lon), as.vector(modelp1$grid$lat))
+
+  r <- raster(ncols=regrid_ll$grid$nx, nrows=regrid_ll$grid$ny, xmn=rlon[1], xmx=rlon[2], ymn=rlat[1], ymx=rlat[2])
+  # get the (last) indices
+  r1 <- rasterize(xy, r)
+  r2 <- rasterize(xy, r)
+  r3 <- rasterize(xy, r)
+  r4 <- rasterize(xy, r)
+  values(r1) <- as.vector(regrid_ll$varout)
+  values(r2) <- as.vector(regrid_ll$varout2)
+  values(r3) <- as.vector(regrid_ll$varout-regrid_ll$varout2)
+  values(r4) <- as.vector( 100* (regrid_ll$varout-regrid_ll$varout2)/regrid_ll$varout2)
+
+  # Precip range and calcs stuff for good legend
+  if(sum(pbins) == 0 ) {
+    pbins <-c(0,25,50,75,100,125,150,175,200,250)
+    pdbins<-c(-100,-75,-50,-25,0,25,50,75,100)
+  }
+  if(length(cols1) == 0 || length(dcols1) == 0) {
+    cols1 <-c('#ffffe5','#f7fcb9','#d9f0a3','#addd8e','#78c679','#41ab5d','#238443','#006837','#004529')
+    cols1 <-c('#ffffe5','#f7fcb9','#d9f0a3','#addd8e','#78c679','#41ab5d','#238443','#006837','#004529','#e7e1ef','#c994c7','#dd1c77')
+    cols1 <-c('#ffffe5','#f7fcb9','#d9f0a3','#addd8e','#78c679','#41ab5d','#238443','#006837','#004529','#2171b5','#6baed6','#bdd7e7','#eff3ff')
+    dcols1<-c('#543005','#8c510a','#bf812d','#dfc27d','#f6e8c3','#f5f5f5','#c7eae5','#80cdc1','#35978f','#01665e','#003c30')
+  }
+ 
+  pmax  <- max(regrid_ll$varout, regrid_ll$varout2, na.rm=T)
+  pdmax <- max(abs(regrid_ll$varout-regrid_ll$varout2), na.rm=T)
+  if(max(pbins) < pmax) {
+   pbins<-round(c(pbins,pmax))
+  }
+  if(max(pdbins) < pdmax) {
+   pdbins<-round(c(-pdmax,pdbins,pdmax)) 
+  }
+ 
+  modgroup   <-paste(toupper(model),"(mm)")
+  obsgroup   <-paste("PRISM (mm)")
+  diffgroup  <-paste(toupper(model),"-PRISM (mm)",sep="")
+  diffpgroup <-paste(toupper(model),"-PRISM (%)",sep="")
+
+  transp<-0.65
+
+  pal1 <- colorBin(cols1, values(r1), na.color = "transparent",pretty=T,bins=pbins)
+  pal2 <- colorBin(cols1, values(r2), na.color = "transparent",pretty=T,bins=pbins)
+  pal3 <- colorBin(dcols1, values(r3), na.color = "transparent",pretty=T,bins=pdbins)
+  pal4 <- colorBin(dcols1, values(r4), na.color = "transparent",pretty=T,bins=c(-250,seq(-100,100,by=25),250))
+
+  my.leaf<-leaflet() %>% addTiles() %>%
+  addRasterImage(flip(r1,"y"), colors = pal1, opacity = transp, group=modgroup) %>%
+  addRasterImage(flip(r2,"y"), colors = pal2, opacity = transp, group=obsgroup) %>%
+  addRasterImage(flip(r3,"y"), colors = pal3, opacity = transp, group=diffgroup) %>%
+  addRasterImage(flip(r4,"y"), colors = pal4, opacity = transp, group=diffpgroup) %>%
+  addLegend(pal = pal1, values = values(r1),title = "Total Precipitation (mm)")  %>%
+  addLegend(pal = pal3, values = values(r3),title = "Diff Precipitation (mm)")  %>%
+  addLegend(pal = pal4, values = values(r4),title = "Diff Precipitation (%)")  %>%
+  addLayersControl(overlayGroups = c(modgroup, obsgroup, diffgroup, diffpgroup), 
+                   options = layersControlOptions(collapsed = FALSE))  %>%
+  hideGroup(c(modgroup,diffgroup,diffpgroup))
+  saveWidget(my.leaf, file=leaffile, selfcontained=T)
+  writeLines(paste("Leaflet HTML output:",leaffile))
+  writeLines(paste("            "))
+ } else {
+  writeLines(paste("     Leaflet plot output option can be enabled if PRISM raster data is set.   "))
+  writeLines(paste("       i.e. setenv PRISM_BIL   T"))
+ }
+ ###################################################################################
+#
 ###############################################################################################
 
 

--- a/scripts_analysis/metExample_mpas/run_prism_comp.csh
+++ b/scripts_analysis/metExample_mpas/run_prism_comp.csh
@@ -11,21 +11,157 @@
 #                          USER CONFIGURATION OPTIONS
 
  ##########################################################################
- # External executables (NCO and R) required for precip evaluation
- # NCO programs to create NetCDF file with model and prism precip.
+ # External executables, netCDF Operators (NCO) are required + R packages
+ # NCO programs are used to create NetCDF file with model and prism precip.
  # See: http://nco.sourceforge.net/
- set ncks     = /usr/local/apps/nco-4.6.6/intel-17.0/bin/ncks
- set ncrename = /usr/local/apps/nco-4.6.6/intel-17.0/bin/ncrename
- set ncatted  = /usr/local/apps/nco-4.6.6/intel-17.0/bin/ncatted
-
- # Set Main R directories, function library and R script
- setenv R_LIBS   /usr/local/apps/R-3.4.0/intel-17.0/lib64/R/library
- setenv R_HOME   /usr/local/apps/R-3.4.0/intel-17.0/lib64/R
- setenv R_SCRIPT $AMETBASE/R_analysis_code/MET_prism_precip.R
+ # R modules needed for Leaflet HTML: prism, raster, leaflet and htmlwidget
+ set ncks     = ncks
+ set ncrename = ncrename
+ set ncatted  = ncatted
  ##########################################################################
 
- # Project/Model ID name
- setenv AMET_PROJECT metExample_mpas
+ # AMETBASE directory and AMET Project ID
+ # setenv AMETBASE     /home/user/AMET
+
+  setenv AMET_PROJECT metExample_mpas
+
+  # Model output directory path
+  setenv METOUT_DIR   $AMETBASE/model_data/MET/$AMET_PROJECT
+  
+  # Prefix of model output file names with trailing _ or .
+  # common examples below.
+  setenv METOUT_PRE   history.subset.
+
+  # Period begin and end day. 
+  # Daily:       Daily analysis done for each day of the period
+  # Monthly:     Start day needs to be first day of the month. Loop ends the month of end date.
+  # Annual:      Start day needs to be first day of the year. Loop ends the year of the end date.
+  # Single Anal: For single daily, monthly or annual analysis set begin = end day and anal period.
+  set begday    =     20160701
+  set endday    =     20160701
+
+ # Note that this script only works for continous simulations where rainc and rainnc are the accumulated
+ # precip over the period not reset each day. Users have to match the model start and end day with time
+ # time index to the daily or monthly PRISM dataset above as there is no internal verification that the
+ # start and end model dates reflect the PRISM dataset period. The PRISM dataset is keyed off the model 
+ # start files date stamp with formats like 2016-12-01_00:00:00.
+ # Model settings are either wrf or mpas and used only for the output file generation
+ set model    = mpas
+
+ # PRISM ASCII file information. Prefix examples are below for old ASCII format PRISM data.
+ # Data: http://prism.oregonstate.edu/recent/
+ # Users can choose the daily or monthly data for a year or month. Choose the .asc (ASCII) files.
+ # Download and extract to a PRISM archive directory. Specify that below via PRISM_DIR and correct
+ # PRISM_PREFIX setting. Here is an example file: PRISM_ppt_stable_4kmM3_201610_asc.asc
+ # Note that PREFIX are all characters up to the date stamp.
+ setenv PRISM_PREFIX PRISM_ppt_stable_4kmM3_
+ setenv PRISM_DIR   $AMETBASE/obs/MET/prism
+
+ # New major update in AMET1.5 that leverages the prism package in R that automatically downloads
+ # raster data (.bil files) from PRISM servers. This is the suggested method now necause ASCII 
+ # data has been discontinued. ASCII method is still allowed if users have the old data. 
+ # BIL data usage is simpler and allows the new annual option. ASCII method only allows monthly.
+ setenv PRISM_BIL  T 
+
+ # Is this a daily precip evaluation?
+ # Daily only works with BIL option now. If daily is TRUE, BIL will be automatically used.
+ setenv DAILY F
+
+ # Is this an annual precip evaluation?
+ # Montly assumed if daily=F and annual=F.
+ setenv ANNUAL F
+
+ # Leaflet lat-lon grid spacing in kilometers (km). 
+ # -99 will result in lat-lon grid spacing of the model grid
+ setenv LEAF_DXDYKM -99
+
+ # Leaflet plot levels, and color scales
+ # LEAF_DXDYKM -99 will use model grid spacing. Positive value (km) will override model DX specification.
+ # NOTE: LEAF_DXDYKM >> Model DX produces unstable interpolation results.
+ # NOTE: LEAF_DXDYKM << Model DX is more time consuming
+ # Plots include Model, PRISM, Diff and % Diff. 
+ # Two color scales: Total precip (COLOR) and Differences (DCOLOR)
+ # Two level specifications: Total precip (LEVELS) & Difference (DLEVELS)
+ # Good color scale codes: https://colorbrewer2.org/#type=sequential&scheme=BuGn&n=3
+ # These examples are just a guide.
+ set   COLOR=('#ffffe5' '#f7fcb9' '#d9f0a3' '#addd8e' '#78c679' '#41ab5d' '#238443' '#006837' '#004529' '#e7e1ef' '#c994c7' '#dd1c77')
+ set   COLOR=('#ffffe5' '#f7fcb9' '#d9f0a3' '#addd8e' '#78c679' '#41ab5d' '#238443' '#006837' '#004529')
+ set   COLOR=('#ffffe5' '#f7fcb9' '#d9f0a3' '#addd8e' '#78c679' '#41ab5d' '#238443' '#006837' '#004529' '#2171b5' '#6baed6' '#bdd7e7' '#eff3ff') 
+ set  DCOLOR=('#543005' '#8c510a' '#bf812d' '#dfc27d' '#f6e8c3' '#f5f5f5' '#c7eae5' '#80cdc1' '#35978f' '#01665e' '#003c30')
+
+ # Good settings for Daily precipitation
+ set  LEVELS=(0 1 5 10 15 20 25 50 75 100 150 300)
+ set DLEVELS=(-100 -75 -50 -25 0 25 50 75 100)
+
+ # Good settings for Monthly precipitation
+ set  LEVELS=(0 25 50 75 100 125 150 175 200 250)
+ set DLEVELS=(-250 -100 -50 -25 -15 -5 0 5 15 25 50 100 250)
+
+
+ ## MAIN LOOP for looping over days or months of a year. No real need to loop over years although users
+ ## can alter if needed for long-term simulations.
+set year  = `echo begday |cut -b1-4`
+set date = $begday
+#-- Main LOOP Over Days defined above.
+while ( $date <= $endday )
+
+  setenv YYYYS `echo $date |cut -b1-4`
+  setenv YYS   `echo $date |cut -b3-4`
+  setenv MMS   `echo $date |cut -b5-6`
+  setenv DDS   `echo $date |cut -b7-8`
+
+ if($YYYYS == "2016" || $YYYYS == "2020" || $YYYYS == "2024" || $YYYYS == "2028" || $YYYYS == "2032") then
+   set NUM_DAYS_MON=(31 29 31 30 31 30 31 31 30 31 30 31)
+   set dty=366
+ else
+   set NUM_DAYS_MON=(31 28 31 30 31 30 31 31 30 31 30 31)
+   set dty=365
+ endif
+
+ if($ANNUAL == "T") then
+    setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-01-01_00:00:00
+    if($model == "mpas") then
+      setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-01-01.nc
+    endif
+    setenv START_TINDEX    1
+    setenv END_TINDEX      1 
+    setenv PRISM_BIL   T
+    setenv OUTFILE ${AMET_PROJECT}.prism-${model}.annual.${YYYYS}.nc
+    set date = `date -d "$date $dty days" '+%Y%m%d' `
+ endif
+ if($DAILY == "T") then
+    set dt=1
+    setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-${MMS}-${DDS}_00:00:00
+    if($model == "mpas") then
+      setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-${MMS}-${DDS}.nc
+    endif
+    setenv START_TINDEX    1
+    setenv END_TINDEX      1 
+    setenv PRISM_BIL   T
+    setenv OUTFILE ${AMET_PROJECT}.prism-${model}.daily.${YYYYS}${MMS}${DDS}.nc
+    set date = `date -d "$date $dt days" '+%Y%m%d' `
+ endif
+ if($DAILY == "F" & $ANNUAL == "F") then
+    set dt=$NUM_DAYS_MON[$MMS]
+    setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-${MMS}-01_00:00:00
+    if($model == "mpas") then
+      setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-${MMS}-01.nc
+    endif
+    setenv START_TINDEX    1
+    setenv END_TINDEX      1 
+    setenv OUTFILE ${AMET_PROJECT}.prism-${model}.monthly.${YYYYS}${MMS}.nc
+    set date = `date -d "$date $dt days" '+%Y%m%d' `
+ endif
+
+  setenv YYYYE `echo $date |cut -b1-4`
+  setenv YYE   `echo $date |cut -b3-4`
+  setenv MME   `echo $date |cut -b5-6`
+  setenv DDE   `echo $date |cut -b7-8`
+
+  setenv MODEL_END      ${METOUT_DIR}/${METOUT_PRE}${YYYYE}-${MME}-${DDE}_00:00:00 
+  if($model == "mpas") then
+    setenv MODEL_END      ${METOUT_DIR}/${METOUT_PRE}${YYYYE}-${MME}-${DDE}.nc
+  endif
 
  # New NetCDF file that will contain model (MODEL_PRECIP_MM) and prism precip (PRISM_PRECIP_MM).
  # This file is created using NCO (NetCDF Operator executables) ncks, ncatted and ncrename.
@@ -33,44 +169,6 @@
  # $AMETBASE/output/$AMET_PROJECT/prism/
  # The NetCDF file is easily viewed and plotted in almost all NetCDF capable vis software
  # For MPAS Verdi is suggested since its grid is unstructured.
- setenv OUTFILE metExample_mpas.precip.jul2016.nc
-
- # PRISM data information. Prefix examples from a 2013 and 2016 download are below.
- # There are near-real time provisional and later released final/stable versions of the
- # datasets. Also monthly (M3) and daily (D2) grids. Users must pick the datasets that properly
- # match the model output files and time increments in those files.
- # Data: http://prism.oregonstate.edu/recent/
- # Data   FTP: ftp://prism.oregonstate.edu/
- # Users can choose the daily or monthly data for a year or month. Choose the .asc (ASCII) files.
- # Download and extract to a PRISM archive directory. Specify that below via PRISM_DIR and correct
- # PRISM_PREFIX setting. Here is an example file: PRISM_ppt_stable_4kmM3_201610_asc.asc
- # Note that PREFIX are all characters up to the date stamp.
- # Bulk FTP for daily can be found here: ftp://prism.nacse.org/daily/ppt/
- # Bulk FTP for daily can be found here: ftp://prism.nacse.org/monthly/ppt/
- setenv PRISM_PREFIX PRISM_ppt_stable_4kmD2_
- setenv PRISM_PREFIX PRISM_ppt_provisional_4kmD2_
- setenv PRISM_PREFIX PRISM_ppt_stable_4kmM3_
-
- setenv PRISM_DIR   $AMETBASE/obs/MET/prism_daily
- setenv PRISM_DIR   $AMETBASE/obs/MET/prism
-
- # Note that this script only works for continous simulations where rainc and rainnc are the accumulated
- # precip over the month and not reset each day. Users have to match the model start and end day with time
- # time index to the daily or monthly PRISM dataset above as there is no internal verification that the
- # start and end model dates reflect the PRISM dataset period. The PRISM dataset is keyed off the model 
- # start files date stamp with formats of wrfout_d01_2016-12-01_00:00:00 (WRF) and history.2016-12-01.nc(MPAS).
- # Model settings are either wrf or mpas and used only for the output file generation
- set model    = mpas
- setenv MODEL_START     $AMETBASE/model_data/MET/$AMET_PROJECT/history.subset.2016-07-01.nc
- setenv MODEL_END       $AMETBASE/model_data/MET/$AMET_PROJECT/history.subset.2016-07-31.nc
-
- setenv START_TINDEX    1
- setenv END_TINDEX      24
-
- # Is this a daily precip evaluation? Otherwise it's assumed monthly. This is only needed
- # to choose the correct prism dataset name that is date dependent.
- # PRISM_ppt_stable_4kmM3_201604_asc.asc (monthly) vs. PRISM_ppt_provisional_4kmD2_20160609_asc.asc
- setenv DAILY  F
 
  #######################################################################################
  # Do not alter unless you want to change the output NetCDF file structure.
@@ -79,6 +177,11 @@
  mkdir -p $AMETBASE/output/$AMET_PROJECT
  mkdir -p $AMETBASE/output/$AMET_PROJECT/prism
  setenv OUTFILE $AMETBASE/output/$AMET_PROJECT/prism/$OUTFILE
+ setenv LEAF_COLOR    "$COLOR[*]"
+ setenv LEAF_DCOLOR   "$DCOLOR[*]"
+ setenv LEAF_LEVELS   "$LEVELS[*]"
+ setenv LEAF_DLEVELS  "$DLEVELS[*]"
+
  if($model == 'wrf') then
    $ncks -O -v Times -d Time,0,0   $MODEL_START $OUTFILE
    $ncks -A -v RAINC -d Time,0,0   $MODEL_START $OUTFILE
@@ -106,8 +209,10 @@
  endif
  #######################################################################################
 
- $R_HOME/bin/R --no-save --slave  < $R_SCRIPT
+ R --no-save --slave  < $AMETBASE/R_analysis_code/MET_prism_precip.R
 
- exit(0)
+ ###########################################################
+
+end
 
 ##########################################################################################################

--- a/scripts_analysis/metExample_wrf/run_prism_comp.csh
+++ b/scripts_analysis/metExample_wrf/run_prism_comp.csh
@@ -11,22 +11,158 @@
 #                          USER CONFIGURATION OPTIONS
 
  ##########################################################################
- # External executables (NCO and R) required for precip evaluation
- # NCO programs to create NetCDF file with model and prism precip.
+ # External executables, netCDF Operators (NCO) are required + R packages
+ # NCO programs are used to create NetCDF file with model and prism precip.
  # See: http://nco.sourceforge.net/
+ # R modules needed for Leaflet HTML: prism, raster, leaflet and htmlwidget
  set ncks     = ncks
  set ncrename = ncrename
  set ncatted  = ncatted
-
- # Set Main R directories, function library and R script
- setenv R_LIBS   /nas/longleaf/home/lizadams/Rlibs
- setenv R_HOME   /nas/longleaf/apps/r/4.1.3/lib64/R
- setenv R_SCRIPT $AMETBASE/R_analysis_code/MET_prism_precip.R
  ##########################################################################
 
- # Project/Model ID name
+ # AMETBASE directory and AMET Project ID
+ # setenv AMETBASE     /home/user/AMET
 
- setenv AMET_PROJECT metExample_wrf
+  setenv AMET_PROJECT metExample_wrf
+
+  # Model output directory path
+  setenv METOUT_DIR   $AMETBASE/model_data/MET/$AMET_PROJECT
+  
+  # Prefix of model output file names with trailing _ or .
+  # common examples below.
+  setenv METOUT_PRE   wrfout_d01_
+  setenv METOUT_PRE   wrfout_subset_
+
+  # Period begin and end day. 
+  # Daily:       Daily analysis done for each day of the period
+  # Monthly:     Start day needs to be first day of the month. Loop ends the month of end date.
+  # Annual:      Start day needs to be first day of the year. Loop ends the year of the end date.
+  # Single Anal: For single daily, monthly or annual analysis set begin = end day and anal period.
+  set begday    =     20160701
+  set endday    =     20160701
+
+ # Note that this script only works for continous simulations where rainc and rainnc are the accumulated
+ # precip over the period not reset each day. Users have to match the model start and end day with time
+ # time index to the daily or monthly PRISM dataset above as there is no internal verification that the
+ # start and end model dates reflect the PRISM dataset period. The PRISM dataset is keyed off the model 
+ # start files date stamp with formats like 2016-12-01_00:00:00.
+ # Model settings are either wrf or mpas and used only for the output file generation
+ set model    = wrf
+
+ # PRISM ASCII file information. Prefix examples are below for old ASCII format PRISM data.
+ # Data: http://prism.oregonstate.edu/recent/
+ # Users can choose the daily or monthly data for a year or month. Choose the .asc (ASCII) files.
+ # Download and extract to a PRISM archive directory. Specify that below via PRISM_DIR and correct
+ # PRISM_PREFIX setting. Here is an example file: PRISM_ppt_stable_4kmM3_201610_asc.asc
+ # Note that PREFIX are all characters up to the date stamp.
+ setenv PRISM_PREFIX PRISM_ppt_stable_4kmM3_
+ setenv PRISM_DIR   $AMETBASE/obs/MET/prism
+
+ # New major update in AMET1.5 that leverages the prism package in R that automatically downloads
+ # raster data (.bil files) from PRISM servers. This is the suggested method now necause ASCII 
+ # data has been discontinued. ASCII method is still allowed if users have the old data. 
+ # BIL data usage is simpler and allows the new annual option. ASCII method only allows monthly.
+ setenv PRISM_BIL   T
+
+ # Is this a daily precip evaluation?
+ # Daily only works with BIL option now. If daily is TRUE, BIL will be automatically used.
+ setenv DAILY F
+
+ # Is this an annual precip evaluation?
+ # Montly assumed if daily=F and annual=F.
+ setenv ANNUAL F
+
+ # Leaflet lat-lon grid spacing in kilometers (km). 
+ # -99 will result in lat-lon grid spacing of the model grid
+ setenv LEAF_DXDYKM -99
+
+ # Leaflet plot levels, and color scales
+ # LEAF_DXDYKM -99 will use model grid spacing. Positive value (km) will override model DX specification.
+ # NOTE: LEAF_DXDYKM >> Model DX produces unstable interpolation results.
+ # NOTE: LEAF_DXDYKM << Model DX is more time consuming
+ # Plots include Model, PRISM, Diff and % Diff. 
+ # Two color scales: Total precip (COLOR) and Differences (DCOLOR)
+ # Two level specifications: Total precip (LEVELS) & Difference (DLEVELS)
+ # Good color scale codes: https://colorbrewer2.org/#type=sequential&scheme=BuGn&n=3
+ # These examples are just a guide.
+ set   COLOR=('#ffffe5' '#f7fcb9' '#d9f0a3' '#addd8e' '#78c679' '#41ab5d' '#238443' '#006837' '#004529' '#e7e1ef' '#c994c7' '#dd1c77')
+ set   COLOR=('#ffffe5' '#f7fcb9' '#d9f0a3' '#addd8e' '#78c679' '#41ab5d' '#238443' '#006837' '#004529')
+ set   COLOR=('#ffffe5' '#f7fcb9' '#d9f0a3' '#addd8e' '#78c679' '#41ab5d' '#238443' '#006837' '#004529' '#2171b5' '#6baed6' '#bdd7e7' '#eff3ff') 
+ set  DCOLOR=('#543005' '#8c510a' '#bf812d' '#dfc27d' '#f6e8c3' '#f5f5f5' '#c7eae5' '#80cdc1' '#35978f' '#01665e' '#003c30')
+
+ # Good settings for Daily precipitation
+ set  LEVELS=(0 1 5 10 15 20 25 50 75 100 150 300)
+ set DLEVELS=(-100 -75 -50 -25 0 25 50 75 100)
+
+ # Good settings for Monthly precipitation
+ set  LEVELS=(0 25 50 75 100 125 150 175 200 250)
+ set DLEVELS=(-250 -100 -50 -25 -15 -5 0 5 15 25 50 100 250)
+
+
+ ## MAIN LOOP for looping over days or months of a year. No real need to loop over years although users
+ ## can alter if needed for long-term simulations.
+set year  = `echo begday |cut -b1-4`
+set date = $begday
+#-- Main LOOP Over Days defined above.
+while ( $date <= $endday )
+
+  setenv YYYYS `echo $date |cut -b1-4`
+  setenv YYS   `echo $date |cut -b3-4`
+  setenv MMS   `echo $date |cut -b5-6`
+  setenv DDS   `echo $date |cut -b7-8`
+
+ if($YYYYS == "2016" || $YYYYS == "2020" || $YYYYS == "2024" || $YYYYS == "2028" || $YYYYS == "2032") then
+   set NUM_DAYS_MON=(31 29 31 30 31 30 31 31 30 31 30 31)
+   set dty=366
+ else
+   set NUM_DAYS_MON=(31 28 31 30 31 30 31 31 30 31 30 31)
+   set dty=365
+ endif
+
+ if($ANNUAL == "T") then
+    setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-01-01_00:00:00
+    if($model == "mpas") then
+      setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-01-01.nc
+    endif
+    setenv START_TINDEX    1
+    setenv END_TINDEX      1 
+    setenv PRISM_BIL   T
+    setenv OUTFILE ${AMET_PROJECT}.prism-${model}.annual.${YYYYS}.nc
+    set date = `date -d "$date $dty days" '+%Y%m%d' `
+ endif
+ if($DAILY == "T") then
+    set dt=1
+    setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-${MMS}-${DDS}_00:00:00
+    if($model == "mpas") then
+      setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-${MMS}-${DDS}.nc
+    endif
+    setenv START_TINDEX    1
+    setenv END_TINDEX      1 
+    setenv PRISM_BIL   T
+    setenv OUTFILE ${AMET_PROJECT}.prism-${model}.daily.${YYYYS}${MMS}${DDS}.nc
+    set date = `date -d "$date $dt days" '+%Y%m%d' `
+ endif
+ if($DAILY == "F" & $ANNUAL == "F") then
+    set dt=$NUM_DAYS_MON[$MMS]
+    setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-${MMS}-01_00:00:00
+    if($model == "mpas") then
+      setenv MODEL_START    ${METOUT_DIR}/${METOUT_PRE}${YYYYS}-${MMS}-01.nc
+    endif
+    setenv START_TINDEX    1
+    setenv END_TINDEX      1 
+    setenv OUTFILE ${AMET_PROJECT}.prism-${model}.monthly.${YYYYS}${MMS}.nc
+    set date = `date -d "$date $dt days" '+%Y%m%d' `
+ endif
+
+  setenv YYYYE `echo $date |cut -b1-4`
+  setenv YYE   `echo $date |cut -b3-4`
+  setenv MME   `echo $date |cut -b5-6`
+  setenv DDE   `echo $date |cut -b7-8`
+
+  setenv MODEL_END      ${METOUT_DIR}/${METOUT_PRE}${YYYYE}-${MME}-${DDE}_00:00:00 
+  if($model == "mpas") then
+    setenv MODEL_END      ${METOUT_DIR}/${METOUT_PRE}${YYYYE}-${MME}-${DDE}.nc
+  endif
 
  # New NetCDF file that will contain model (MODEL_PRECIP_MM) and prism precip (PRISM_PRECIP_MM).
  # This file is created using NCO (NetCDF Operator executables) ncks, ncatted and ncrename.
@@ -34,45 +170,6 @@
  # $AMETBASE/output/$AMET_PROJECT/prism/
  # The NetCDF file is easily viewed and plotted in almost all NetCDF capable vis software
  # For MPAS Verdi is suggested since its grid is unstructured.
- setenv OUTFILE metExample_wrf.precip.jul2016.nc
-
- # PRISM data information. Prefix examples from a 2013 and 2016 download are below.
- # There are near-real time provisional and later released final/stable versions of the
- # datasets. Also monthly (M3) and daily (D2) grids. Users must pick the datasets that properly
- # match the model output files and time increments in those files.
- # Data: http://prism.oregonstate.edu/recent/
- # Data   FTP: ftp://prism.oregonstate.edu/
- # Users can choose the daily or monthly data for a year or month. Choose the .asc (ASCII) files.
- # Download and extract to a PRISM archive directory. Specify that below via PRISM_DIR and correct
- # PRISM_PREFIX setting. Here is an example file: PRISM_ppt_stable_4kmM3_201610_asc.asc
- # Note that PREFIX are all characters up to the date stamp.
- # Bulk FTP for daily can be found here: ftp://prism.nacse.org/daily/ppt/
- # Bulk FTP for daily can be found here: ftp://prism.nacse.org/monthly/ppt/
- setenv PRISM_PREFIX PRISM_ppt_stable_4kmD2_
- setenv PRISM_PREFIX PRISM_ppt_provisional_4kmD2_
- setenv PRISM_PREFIX PRISM_ppt_stable_4kmM3_
-
- setenv PRISM_DIR   $AMETBASE/obs/MET/prism_daily
- setenv PRISM_DIR   $AMETBASE/obs/MET/prism
-
- # Note that this script only works for continous simulations where rainc and rainnc are the accumulated
- # precip over the month and not reset each day. Users have to match the model start and end day with time
- # time index to the daily or monthly PRISM dataset above as there is no internal verification that the
- # start and end model dates reflect the PRISM dataset period. The PRISM dataset is keyed off the model 
- # start files date stamp with formats of wrfout_d01_2016-12-01_00:00:00 (WRF) and history.2016-12-01.nc(MPAS).
- # Model settings are either wrf or mpas and used only for the output file generation
- set model    = wrf
-
- setenv MODEL_START     $AMETBASE/model_data/MET/$AMET_PROJECT/wrfout_subset_2016-07-01_00:00:00
- setenv MODEL_END       $AMETBASE/model_data/MET/$AMET_PROJECT/wrfout_subset_2016-07-31_00:00:00
-
- setenv START_TINDEX    1
- setenv END_TINDEX      24
-
- # Is this a daily precip evaluation? Otherwise it's assumed monthly. This is only needed
- # to choose the correct prism dataset name that is date dependent.
- # PRISM_ppt_stable_4kmM3_201604_asc.asc (monthly) vs. PRISM_ppt_provisional_4kmD2_20160609_asc.asc
- setenv DAILY  F
 
  #######################################################################################
  # Do not alter unless you want to change the output NetCDF file structure.
@@ -81,6 +178,11 @@
  mkdir -p $AMETBASE/output/$AMET_PROJECT
  mkdir -p $AMETBASE/output/$AMET_PROJECT/prism
  setenv OUTFILE $AMETBASE/output/$AMET_PROJECT/prism/$OUTFILE
+ setenv LEAF_COLOR    "$COLOR[*]"
+ setenv LEAF_DCOLOR   "$DCOLOR[*]"
+ setenv LEAF_LEVELS   "$LEVELS[*]"
+ setenv LEAF_DLEVELS  "$DLEVELS[*]"
+
  if($model == 'wrf') then
    $ncks -O -v Times -d Time,0,0   $MODEL_START $OUTFILE
    $ncks -A -v RAINC -d Time,0,0   $MODEL_START $OUTFILE
@@ -108,8 +210,10 @@
  endif
  #######################################################################################
 
- $R_HOME/bin/R --no-save --slave  < $R_SCRIPT
+ R --no-save --slave  < $AMETBASE/R_analysis_code/MET_prism_precip.R
 
- exit(0)
+ ###########################################################
+
+end
 
 ##########################################################################################################


### PR DESCRIPTION
This is a significant update to the PRISM-WRF/MPAS analysis. Code has notes.

PRISM now only distributes raster data in BIL format. Main R script was updated to use a prism R package that downloads and reads BIL data. An R raster package provides the data in arrays and allows for the Raster layer for plotting via the Leaflets package. Leaflets package is needed for the interactive HTML plots of PRISM and WRF/MPAS precip.
