### PR TITLE
Update R code where static file is missing (backward compatibility)

### DIFF
--- a/R_analysis_code/MET_plot_radiation.R
+++ b/R_analysis_code/MET_plot_radiation.R
@@ -81,7 +81,7 @@
  source (paste(ametR,"/MET_amet.stats-lib.R",sep=""))
  source (mysqlloginconfig)
  source (ametRinput)
- source (ametRstatic)
+ try(source (ametRstatic),silent=T)
 
  ametdbase1   <- Sys.getenv("AMET_DATABASE")
  ametdbase2   <- Sys.getenv("AMET_DATABASE2")

--- a/R_analysis_code/MET_raob.R
+++ b/R_analysis_code/MET_raob.R
@@ -83,7 +83,7 @@
  source (paste(ametR,"/MET_amet.stats-lib.R",sep=""))
  source (mysqlloginconfig)
  source (ametRinput)
- source (ametRstatic)
+ try(source (ametRstatic),silent=T)
 
  # New runid setting for plot labels. If not set, empty for old plot names.
  if(!exists("runid"))                          { runid <- "NORUNID"  }

--- a/R_analysis_code/MET_spatial_surface.R
+++ b/R_analysis_code/MET_spatial_surface.R
@@ -96,7 +96,7 @@
  source (paste(ametR,"/MET_amet.stats-lib.R",sep=""))
  source (mysqlloginconfig)
  source (ametRinput)
- source (ametRstatic)
+ try(source (ametRstatic),silent=T)
 
  ametdbase      <- Sys.getenv("AMET_DATABASE")
  mysqlserver    <- Sys.getenv("MYSQL_SERVER")

--- a/R_analysis_code/MET_timeseries.R
+++ b/R_analysis_code/MET_timeseries.R
@@ -79,7 +79,7 @@
  source (paste(ametR,"/MET_amet.stats-lib.R",sep=""))
  source (mysqlloginconfig)
  source (ametRinput)
- source (ametRstatic)
+ try(source (ametRstatic),silent=T)
 
  # Compatibility check for new variables in case of old config files
  if(!exists("extra2") ) { extra2 <- extra	}

--- a/R_analysis_code/MET_timeseries_rh.R
+++ b/R_analysis_code/MET_timeseries_rh.R
@@ -61,7 +61,7 @@
  source (paste(ametR,"/MET_amet.stats-lib.R",sep=""))
  source (mysqlloginconfig)
  source (ametRinput)
- source (ametRstatic)
+ try(source (ametRstatic),silent=T)
 
  # Compatibility check for new variables in case of old config files
  if(!exists("extra2") ) { extra2 <- extra	}

--- a/R_analysis_code/MET_wrapper.R
+++ b/R_analysis_code/MET_wrapper.R
@@ -49,7 +49,7 @@
  source (paste(ametR,"/MET_amet.stats-lib.R",sep=""))
  source (mysqlloginconfig)
  source (ametRinput)
- source (ametRstatic)
+ try(source (ametRstatic),silent=T)
 
  ametdbase1   <- Sys.getenv("AMET_DATABASE")
  mysqlserver  <- Sys.getenv("MYSQL_SERVER")


### PR DESCRIPTION
Newer versions of R do not allow empty file loads and this impacted the the backward compatibility of AMET in terms of the new static file convention that was implemented for the AMET GUI. And for the wrapper.csh script. Try statement was added so R would not fault if the AMET static file is empty or not availiable.