### PR TITLE
Updating US EPA AMET develop to match 1.5 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Atmospheric Model Evaluation Tool (AMET) is a suite of software designed to 
        - New model-to-model desity scatter plot (AQ_Scatterplot_mtom_density.R)
        - New species plotly (interactive) time series plot (AQ_Timeseries_species_plotly.R)
        - New multi-species plotly (interactive) time series plot (AQ_Timeseries_multi_species_plotly.R)
--	New AQ analysis script options (docs/AMET_User_Guide_v15.md#aq-analysis-input-files)
+-	New AQ analysis script options
        - Increased number of individual projects that can be specified from 10 to 20
        - Kelly plots have been updated to better choose default plot ranges
        - Added ability to further customize Kelly plots through input options (min, max, interval, etc.)

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ The Atmospheric Model Evaluation Tool (AMET) is a suite of software designed to 
        - include CAPMON
 -	Added option to rename an existing AQ project while retaining existing data
 -	Updated AQ observation files (see notes in [AMET_Release_Observation_Files_Readme.txt](https://github.com/USEPA/AMET/files/8655699/AMET_Release_Observation_Files_Readme.txt))
-       - AMETv1.5 requires these updated observation files
-       - Similarly, the updated observation files require AMETv1.5
+       - AMETv1.5 requires the use of these updated observation files
+       - Similarly, the updated observation files require the use of AMETv1.5
 -	See [AMETv1.5 FAQ](docs/AMET_FAQ.md) for all MET bug fixes and updates. Key updates are listed below.
        - Added forecast and model initialization hours as database fields for the case of WRF or MPAS model forecast evaluations
        - NOAA SURface RADition (SURFRAD) Network option for real or near-real-time modeling (BSRN has a curation delay of months) + autoFTP of those data

--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ The Atmospheric Model Evaluation Tool (AMET) is a suite of software designed to 
        - include CAPMON
 -	Added option to rename an existing AQ project while retaining existing data
 -	Updated AQ observation files (see notes in [AMET_Release_Observation_Files_Readme.txt](https://github.com/USEPA/AMET/files/8655699/AMET_Release_Observation_Files_Readme.txt))
--	See [AMETv5.1 FAQ](docs/AMET_FAQ.md) for all MET bug fixes and updates. Key updates are listed below.
+       - AMETv1.5 requires these updated observation files
+       - Similarly, the updated observation files require AMETv1.5
+-	See [AMETv1.5 FAQ](docs/AMET_FAQ.md) for all MET bug fixes and updates. Key updates are listed below.
        - Added forecast and model initialization hours as database fields for the case of WRF or MPAS model forecast evaluations
        - NOAA SURface RADition (SURFRAD) Network option for real or near-real-time modeling (BSRN has a curation delay of months) + autoFTP of those data
        - QC settings of allowable observed variable range and maximum model-observation difference configurable via R input files

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This AMET Git archive is organized with each official public release stored as a
 To clone code from the AMET Git archive, specify the branch (i.e. version number) and issue the following command from within
 a working directory on your server:
 ```
-git clone -b master https://github.com/USEPA/AMET.git AMET_v15
+git clone -b 1.5 https://github.com/USEPA/AMET.git AMET_v15
 ```
 
 Earlier release versions of AMET that are currently available on Git Hub include:

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ The Atmospheric Model Evaluation Tool (AMET) is a suite of software designed to 
        - New multi-species plotly (interactive) time series plot (AQ_Timeseries_multi_species_plotly.R)
 -	New AQ analysis script options (docs/AMET_User_Guide_v15.md#aq-analysis-input-files)
        - Increased number of individual projects that can be specified from 10 to 20
-       - Kelly plots have been updated better choose default plot ranges
-       - Added ability to further customize Kelly plots through input options (min, max, interval)
+       - Kelly plots have been updated to better choose default plot ranges
+       - Added ability to further customize Kelly plots through input options (min, max, interval, etc.)
        - Added function to only use common sites between multiple projects (useful for comparing data from two different sized domains)
 -	Updated AQ batch scripts to incorporate new analysis scripts
 -	Updated AQ_species_list.input file to:
        - properly map species in the updated AMET observation files (specifically related to EC/OC)
-       - include additional species
+       - include additional species (e.g., 88101 and 88502 PM2.5)
        - include CAPMON
 -	Added option to rename an existing AQ project while retaining existing data
 -	Updated AQ observation files (see notes in [AMET_Release_Observation_Files_Readme.txt](https://github.com/USEPA/AMET/files/8655699/AMET_Release_Observation_Files_Readme.txt))

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The Atmospheric Model Evaluation Tool (AMET) is a suite of software designed to 
        - New model-to-model desity scatter plot (AQ_Scatterplot_mtom_density.R)
        - New species plotly (interactive) time series plot (AQ_Timeseries_species_plotly.R)
        - New multi-species plotly (interactive) time series plot (AQ_Timeseries_multi_species_plotly.R)
--	New AQ analysis script options
+-	New AQ analysis script options [(See the AMET User Guide for more details.)](docs/AMET_User_Guide_v15.md#aq-analysis-input-files)
        - Increased number of individual projects that can be specified from 10 to 20
        - Kelly plots have been updated to better choose default plot ranges
        - Added ability to further customize Kelly plots through input options (min, max, interval, etc.)

--- a/R_analysis_code/MET_amet.prism-lib.R
+++ b/R_analysis_code/MET_amet.prism-lib.R
@@ -231,8 +231,9 @@ mpas_precip <-function(model_output,tindex=1,rainc_var="rainc",rainnc_var="rainn
     lon_mpas<- lon_mpas * (180/pi)
     carea   <-sqrt(ncvar_get(m1,varid="areaCell"))/1000
     rain    <-ncvar_get(m1,varid=rainc_var,c(1,tindex),c(-1,1)) + ncvar_get(m1,varid=rainnc_var,c(1,tindex),c(-1,1))
-    landmask<-ncvar_get(m1,varid="xland")
-    landmask<-landmask[,1]
+    landmask<-ncvar_get(m1,varid="xland", start=c(1,1), count=c(-1,1))
+    #landmask<-ncvar_get(m1,varid="xland")
+    #landmask<-landmask[,1]
     lm.na   <-ifelse(landmask == 0, 1, 1)
     lm.na   <-ifelse(landmask == 2, NA, 1)
     ncells  <-dim(lat_mpas)

--- a/docs/AMET_Install_Guide_v15.md
+++ b/docs/AMET_Install_Guide_v15.md
@@ -67,7 +67,7 @@ To download a zip archive of the software, click the "Clone or Download" button 
 
 To clone the AMET installation directory to a Linux server, use the following command:
 
-``git clone -b master https://github.com/USEPA/AMET.git AMET_v14``
+``git clone -b master https://github.com/USEPA/AMET.git AMET_v15``
 
 Note that this command assumes that git is installed on the Linux system.
 

--- a/docs/AMET_User_Guide_v15.md
+++ b/docs/AMET_User_Guide_v15.md
@@ -116,7 +116,7 @@ community to increase AMET functionality.*
     be set by the user for a given evaluation.
 
 Before using AMET and this user’s guide, you must first install the AMET package on your
-system. For information on the installation process, please see the [Atmospheric Model Evaluation Tool (AMET) Installation Guide](https://github.com/USEPA/AMET/blob/1.4b/docs/AMET_Install_Guide_v14b.md).
+system. For information on the installation process, please see the [Atmospheric Model Evaluation Tool (AMET) Installation Guide](https://github.com/USEPA/AMET/blob/1.5/docs/AMET_Install_Guide_v15.md).
 
 <a id="Directory_Structure"></a>
 2. Directory Structure
@@ -566,7 +566,7 @@ MySQL administrator. Note that this is not necessarily the same as the “ametse
 password that will be created using the scripts discussed below.
 
 Note that the database is required for the meteorological side of AMET. 
-However, as of AMETv1.4b, the database is no longer a requirement to process and 
+However, as of AMETv1.4, the database is no longer a requirement to process and 
 analyze air quality data. An option has been added to read the csv output
 files from site compare directly, bypassing the need to use the database. This has 
 both advantages and disadvantages. The primary advantage is that an AMET user would 
@@ -772,7 +772,7 @@ after, the script runs very fast. This is a new option in AMETv1.4. AMETv1.5 add
 ```
 This C-shell is executed like the ones above. It will create a new table wrfExample_wrf_raob specifically
 for profile observations. Like the surface meteorology, this script will download MADIS rawinsonde observations
-and match with the model profiles. This is a new option in AMETv1.4 and allows users to evaluate the entire
+and match with the model profiles. This was a new option added in AMETv1.4 and allows users to evaluate the entire
 troposphere. 
 
 For the metExample_mcip, the `matching_raob.csh` needs to increment over the number of days.
@@ -924,7 +924,7 @@ also a more comprehensive script that performs both the pre analysis functions (
 and the post analysis functions (e.g. running site compare and AMET). That script is named 
 aqExample_pre_and_post.csh and can also found in the $AMETBASE/scripts_db/aqExample directory. 
 Instructions for using that script can be found in a separate guide here:
-[aqProject Pre and Post Analysis Script Guide](https://github.com/USEPA/AMET/tree/1.4b/docs/AMET_aqProject_Pre_and_Post_Analysis_Script_Guide_v14b.md). 
+[aqProject Pre and Post Analysis Script Guide](https://github.com/USEPA/AMET/tree/1.5/docs/AMET_aqProject_Pre_and_Post_Analysis_Script_Guide_v15.md). 
 
 *TIP: Name the directory of each new project the same name as the AMET_PROJECT
 variable in the database and analysis scripts.*
@@ -1244,7 +1244,7 @@ need to be changed for this example.
 Each script requires an input file, located in the subdirectory `input_files`.
 The input file contains all the options available for each script, and allows
 the user to customize scripts to their liking. Unlike previous version of AMET 
-where each script had its own individual input file, for AMETv1.4b and beyond, 
+where each script had its own individual input file, for AMETv1.4 and beyond, 
 all scripts by default will use the `all_scripts.input` file, which contains 
 all the options available for all the analysis scripts. This eliminates the need 
 to edit each individual input file. 


### PR DESCRIPTION
This was done because develop branch got some updates that did not get pushed to Version 1.5. Some updates to the documentation on the 1.5 branch were never pushed back to develop. This pull request should make develop (coastwx) and US EPA (v1.5) be in sync with US EPA develop branch. All done to start adding new and updated codes.