### PR TITLE
Update AMET for SOLRAD dataset

### DIFF
--- a/R_analysis_code/MET_plot_radiation.R
+++ b/R_analysis_code/MET_plot_radiation.R
@@ -44,6 +44,8 @@
 #             are split into a plot_radiation.static.input & key configs#  
 #             remain in the plot_radiation.input. Backward compatible.  #
 #           - Added auto lat-lon bounds to range of obs sites if missed #
+# Version 1.6, Nov, 2023, Robert Gilliam                                #
+#  Updates: - Added SOLRAD network to the query of data and networks    # 
 #                                                                       #
 #########################################################################
   options(warn=-1)
@@ -101,11 +103,11 @@
 
  query1 <- paste("SELECT  DATE_FORMAT(d.ob_date,'%Y%m%d'),HOUR(d.ob_date), d.stat_id,s.lat, s.lon,",
                  "d.SRAD_mod, d.SRAD_ob FROM ",project1,"_surface d, stations s  WHERE d.stat_id=s.stat_id ", 
-                 "AND (s.ob_network='SRAD' || s.ob_network='BSRN') AND d.SRAD_ob > 0 AND d.ob_date BETWEEN ",
+                 "AND (s.ob_network='SOLRAD' || s.ob_network='SRAD' || s.ob_network='BSRN') AND d.SRAD_ob > 0 AND d.ob_date BETWEEN ",
                  d1," AND ",d2," ",extra," ORDER by d.ob_date", sep="")
  query2 <- paste("SELECT  DATE_FORMAT(d.ob_date,'%Y%m%d'),HOUR(d.ob_date), d.stat_id,s.lat, s.lon,",
                  "d.SRAD_mod, d.SRAD_ob FROM ",project2,"_surface d, stations s  WHERE d.stat_id=s.stat_id ", 
-                 "AND (s.ob_network='SRAD' || s.ob_network='BSRN') AND d.SRAD_ob > 0 AND d.ob_date BETWEEN ",
+                 "AND (s.ob_network='SOLRAD' || s.ob_network='SRAD' || s.ob_network='BSRN') AND d.SRAD_ob > 0 AND d.ob_date BETWEEN ",
                  d1," AND ",d2," ",extra," ORDER by d.ob_date", sep="")
 
  writeLines(paste(query1))

--- a/R_db_code/MET_matching_raob.R
+++ b/R_db_code/MET_matching_raob.R
@@ -6,16 +6,18 @@
 #       Meteorological Models:
 #            Model for Prediction Across Scales (MPAS)
 #            Weather Research and Forecasting Model (WRF) 
+#            Meteorology-Chemistry Interface Processor (MCIP)
+#            NOAA Unified Forecast System (UFS) 
 #                                                  
 #       This "R" script provides an interface to match MADIS
-#       observations with either WRF or MPAS model output and
+#       observations with either WRF, MPAS, MCIP or UFS model output and
 #       insert into AMET configured MySQL database. This specific
 #       script is the master that calls R functions that read
 #       model output, MADIS observations, interpolate, 
 #       and construct the database queries.   
 #
 #       This wrapper matches Rawindsone profiles (Theta, WS/WD and RH)
-#       with either WRF or MPAS meteorology.   
+#       with either WRF, MPAS, UFS and MCIP  
 #                                                            
 #       Developed by the US EPA           
 #                                                                 ################################

--- a/R_db_code/MET_matching_surface.R
+++ b/R_db_code/MET_matching_surface.R
@@ -6,16 +6,18 @@
 #       Meteorological Models:
 #            Model for Prediction Across Scales (MPAS)
 #            Weather Research and Forecasting Model (WRF) 
+#            Meteorology-Chemistry Interface Processor (MCIP)
+#            NOAA Unified Forecast System (UFS) 
 #                                                  
 #       This "R" script provides an interface to match MADIS
-#       observations with either WRF or MPAS model output and
+#       observations with either WRF, MPAS, MCIP or UFS model output and
 #       insert into AMET configured MySQL database. This specific
 #       script is the master that calls R functions that read
 #       model output, MADIS observations, interpolate, 
 #       and construct the database queries.
 #
 #       This wrapper matches surface observations (WS, WS, T, Q and PSFC)
-#       with either WRF or MPAS surface meteorology fields.   
+#       with either WRF, MPAS, MCIP or UFS surface meteorology fields.   
 #                                                            
 #       Developed by the US EPA           
 #                                                                 ################################

--- a/R_db_code/MET_matching_surface_fillmet.R
+++ b/R_db_code/MET_matching_surface_fillmet.R
@@ -6,16 +6,18 @@
 #       Meteorological Models:
 #            Model for Prediction Across Scales (MPAS)
 #            Weather Research and Forecasting Model (WRF) 
+#            Meteorology-Chemistry Interface Processor (MCIP)
+#            NOAA Unified Forecast System (UFS) 
 #                                                  
 #       This "R" script provides an interface to match MADIS
-#       observations with either WRF or MPAS model output and
+#       observations with either WRF, MPAS, MCIP or UFS model output and
 #       insert into AMET configured MySQL database. This specific
 #       script is the master that calls R functions that read
 #       model output, MADIS observations, interpolate, 
 #       and construct the database queries.
 #
 #       This wrapper matches surface observations (WS, WS, T, Q and PSFC)
-#       with either WRF or MPAS surface meteorology fields.   
+#       with either WRF, MPAS, MCIP or UFS surface meteorology fields.   
 #                                                            
 #       Developed by the US EPA           
 #                                                                 ################################

--- a/obs/MET/bsrn/solrad_sites.csv
+++ b/obs/MET/bsrn/solrad_sites.csv
@@ -1,0 +1,10 @@
+"Event, optional label",Event label,Location name,Latitude,Longitude,Elevation,Date/Time,Date/Time end,Comment
+Albuquerque, ABQ, New Mexico USA, 35.03796, -106.62211, 1617,1/1/1995,NA,"SOLRAD USA"
+Bismarck, BIS, North Dakota USA, 46.77179, -100.75955, 503, 1/1/1995, NA, "SOLRAD USA"
+Hanford, HNX, California USA, 36.31357, -119.63164, 73, 1/1/1995, NA, "SOLRAD USA"
+Madison, MSN, Wisconsin USA, 43.07250, -89.41133, 271, 1/1/1995, NA, "SOLRAD USA"
+Oak Ridge, ORT, Tennessee USA, 35.96101, -84.28838, 334, 1/1/1995, NA, "SOLRAD USA"
+Salt Lake City, SLC, Utah USA, 40.77220, -111.95495, 1288, 1/1/1995, NA, "SOLRAD USA"
+Seattle, SEA, Washington USA, 47.68685, -122.25667, 20, 1/1/1995, NA, "SOLRAD USA"
+Sterling, STE, Virginia USA, 38.97203, -77.48690, 85, 1/1/1995, NA, "SOLRAD USA"
+Tallahassee, TLH, Florida USA,	30.39675, -84.32955, 18, 1/1/1995, NA, "SOLRAD USA"

--- a/scripts_analysis/metExample_mcip/run_plot_radiation.csh
+++ b/scripts_analysis/metExample_mcip/run_plot_radiation.csh
@@ -1,16 +1,15 @@
 #!/bin/csh -f
 # -----------------------------------------------------------------------
-# Shortwave Radiation Evaluation using Baseline Surface Radiation Network
-# or US-Based SURFRAD
+# Shortwave Radiation Evaluation using Baseline Surface Radiation Network BSRN,
+# US-Based SURFRAD or SOLRAD
 # -----------------------------------------------------------------------
 # Purpose:
-# Evaluation of MPAS/WRF shortwave radiation using the global BSRN or  
-# SURFRAD observations. Spatial, diurnal, timeseries and histogram plots
+# Evaluation of MPAS/WRF/MCIP/UFS shortwave radiation using the global BSRN,  
+# SURFRAD and/or SOLRAD observations. Spatial, diurnal, timeseries and histogram plots
 # are options along with text outputs.
 # -----------------------------------------------------------------------
 ####################################################################################
-#                          USER CONFIGURATION OPTIONS
-  
+#                          USER CONFIGURATION OPTIONS  
 
   # MySQL Server and AMET database configuration file.
   # For security make file only readable by you. With the following variables

--- a/scripts_analysis/metExample_mpas/run_plot_radiation.csh
+++ b/scripts_analysis/metExample_mpas/run_plot_radiation.csh
@@ -1,16 +1,15 @@
 #!/bin/csh -f
 # -----------------------------------------------------------------------
-# Shortwave Radiation Evaluation using Baseline Surface Radiation Network
-# or US-Based SURFRAD
+# Shortwave Radiation Evaluation using Baseline Surface Radiation Network BSRN,
+# US-Based SURFRAD or SOLRAD
 # -----------------------------------------------------------------------
 # Purpose:
-# Evaluation of MPAS/WRF shortwave radiation using the global BSRN or  
-# SURFRAD observations. Spatial, diurnal, timeseries and histogram plots
+# Evaluation of MPAS/WRF/MCIP/UFS shortwave radiation using the global BSRN,  
+# SURFRAD and/or SOLRAD observations. Spatial, diurnal, timeseries and histogram plots
 # are options along with text outputs.
 # -----------------------------------------------------------------------
 ####################################################################################
-#                          USER CONFIGURATION OPTIONS
-  
+#                          USER CONFIGURATION OPTIONS  
 
   # MySQL Server and AMET database configuration file.
   # For security make file only readable by you. With the following variables

--- a/scripts_analysis/metExample_ufs/run_plot_radiation.csh
+++ b/scripts_analysis/metExample_ufs/run_plot_radiation.csh
@@ -1,16 +1,15 @@
 #!/bin/csh -f
 # -----------------------------------------------------------------------
-# Shortwave Radiation Evaluation using Baseline Surface Radiation Network
-# or US-Based SURFRAD
+# Shortwave Radiation Evaluation using Baseline Surface Radiation Network BSRN,
+# US-Based SURFRAD or SOLRAD
 # -----------------------------------------------------------------------
 # Purpose:
-# Evaluation of MPAS/WRF shortwave radiation using the global BSRN or  
-# SURFRAD observations. Spatial, diurnal, timeseries and histogram plots
+# Evaluation of MPAS/WRF/MCIP/UFS shortwave radiation using the global BSRN,  
+# SURFRAD and/or SOLRAD observations. Spatial, diurnal, timeseries and histogram plots
 # are options along with text outputs.
 # -----------------------------------------------------------------------
 ####################################################################################
 #                          USER CONFIGURATION OPTIONS
-  
 
   # MySQL Server and AMET database configuration file.
   # For security make file only readable by you. With the following variables

--- a/scripts_analysis/metExample_wrf/run_plot_radiation.csh
+++ b/scripts_analysis/metExample_wrf/run_plot_radiation.csh
@@ -1,16 +1,15 @@
 #!/bin/csh -f
 # -----------------------------------------------------------------------
-# Shortwave Radiation Evaluation using Baseline Surface Radiation Network
-# or US-Based SURFRAD
+# Shortwave Radiation Evaluation using Baseline Surface Radiation Network BSRN,
+# US-Based SURFRAD or SOLRAD
 # -----------------------------------------------------------------------
 # Purpose:
-# Evaluation of MPAS/WRF shortwave radiation using the global BSRN or  
-# SURFRAD observations. Spatial, diurnal, timeseries and histogram plots
+# Evaluation of MPAS/WRF/MCIP/UFS shortwave radiation using the global BSRN,  
+# SURFRAD and/or SOLRAD observations. Spatial, diurnal, timeseries and histogram plots
 # are options along with text outputs.
 # -----------------------------------------------------------------------
 ####################################################################################
 #                          USER CONFIGURATION OPTIONS
-  
 
   # MySQL Server and AMET database configuration file.
   # For security make file only readable by you. With the following variables

--- a/scripts_db/metExample_mcip/matching_radiation.csh
+++ b/scripts_db/metExample_mcip/matching_radiation.csh
@@ -11,9 +11,9 @@ setenv AMET_DATABASE amet
 setenv MYSQL_SERVER  localhost
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
 
-# Root directory of MADIS NetCDF obs. Note that this directory should
-# contain subdirectories like this in the standard
-# MADIS directory configuration: $AMETBASE/point/metar/netcdf
+# Root directory of BSRN/SURFRAD/SOLRAD obs (same as MADIS). Note that this directory should
+# contain a subdirectory "bsrn" where this radiation obs dataset (unzipped)
+# BSRN/SURFRAD/SOLRAD directory configuration: $MADISBASE/bsrn 
 setenv MADISBASE $AMETBASE/obs/MET
 
 # A unique AMETPROJECT name for the simulation to evaluated. 
@@ -36,12 +36,12 @@ setenv FORECAST F
 # no time information, so a single file is used for all METCRO2D files.
  setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/METCRO2D
 
-
-# Radiation dataset to match with MPAS, WRF or MCIP -- Only shortwave radiation enabled
-# Options: "bsrn" or "srad"
+# Radiation dataset to match with MPAS, WRF, UFS or MCIP -- Only shortwave radiation enabled
+# Options: "bsrn", "srad" or "solrad"
 # BSRN is a global dataset with a lantency of months
-# SURFRAD is the US-based only SURFRAD Network that is real-time
-# Note: both datasets are downloaded into the $MADISBASE/bsrn directory (different naming)
+# SURFRAD is the US-based only network that is real-time
+# SOLRAD  is the US-based only network that is real-time
+# Note: All datasets are downloaded into the $MADISBASE/bsrn directory (different naming)
 setenv RADIATION_DSET bsrn 
 
 # Interpolation Method for WRF/MCIP Model: 1 - Nearest Neighbor, 2 - Bi-Linear
@@ -73,12 +73,12 @@ setenv UPDATE_SITES T
 # it is the most time consuming part of AMET and that step is bypassed.
 setenv MAX_TIMES_SITE_CHECK 1
 
-# Automatic BSRN and SURFRAD Obs FTP Option. BSRN requires log/pass to access the FTP server.
-# SURFRAD is anonymous with user's work email for their tracking statistics.
+# Automatic BSRN, SOLRAD and SURFRAD Obs FTP Option. BSRN requires log/pass to access the FTP server.
+# SURFRAD/SOLRAD are anonymous with user's work email for their tracking statistics.
 # Also, users must have MADIS directory structure in place and MADISBASE pointing to that directory.
 # Current BSRN server is defined below. Note: only observation within the domain are downloaded.
-# Current NOAA SurfRad server defined in the case of srad option.
-# Both observation dataset are downloaded into MADISBASE/bsrn directory for consolidation.
+# Current NOAA SurfRad and SOLRAD server defined in the case of srad or solrad option.
+# All observation dataset are downloaded into MADISBASE/bsrn directory for consolidation.
 setenv AUTOFTP T
 
 if (${RADIATION_DSET} == "bsrn")  then
@@ -89,6 +89,12 @@ endif
 
 if (${RADIATION_DSET} == "srad")  then
   setenv RAD_SERVER https://gml.noaa.gov/aftp/data/radiation/surfrad
+  setenv RAD_LOGIN  anonymous
+  setenv RAD_PASS   lizadams@email.unc.edu 
+endif
+
+if (${RADIATION_DSET} == "solrad")  then
+  setenv RAD_SERVER https://gml.noaa.gov/aftp/data/radiation/solrad
   setenv RAD_LOGIN  anonymous
   setenv RAD_PASS   lizadams@email.unc.edu
 endif

--- a/scripts_db/metExample_mpas/matching_radiation.csh
+++ b/scripts_db/metExample_mpas/matching_radiation.csh
@@ -11,9 +11,9 @@ setenv AMET_DATABASE amet
 setenv MYSQL_SERVER  localhost
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
 
-# Root directory of BSRN/SURFRAD obs (same as MADIS). Note that this directory should
+# Root directory of BSRN/SURFRAD/SOLRAD obs (same as MADIS). Note that this directory should
 # contain a subdirectory "bsrn" where this radiation obs dataset (unzipped)
-# BSRN/SURFRAD directory configuration: $MADISBASE/bsrn 
+# BSRN/SURFRAD/SOLRAD directory configuration: $MADISBASE/bsrn 
 setenv MADISBASE $AMETBASE/obs/MET
 
 # A unique AMETPROJECT name for the simulation to evaluated. 
@@ -31,11 +31,12 @@ setenv FORECAST F
 # location below. A wildcard (*) is added in the script to get list of outputs.
 setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/history.subset.2016
 
-# Radiation dataset to match with MPAS, WRF or MCIP -- Only shortwave radiation enabled
-# Options: "bsrn" or "srad"
+# Radiation dataset to match with MPAS, WRF, UFS or MCIP -- Only shortwave radiation enabled
+# Options: "bsrn", "srad" or "solrad"
 # BSRN is a global dataset with a lantency of months
-# SURFRAD is the US-based only SURFRAD Network that is real-time
-# Note: both datasets are downloaded into the $MADISBASE/bsrn directory (different naming)
+# SURFRAD is the US-based only network that is real-time
+# SOLRAD  is the US-based only network that is real-time
+# Note: All datasets are downloaded into the $MADISBASE/bsrn directory (different naming)
 setenv RADIATION_DSET bsrn 
 
 # Interpolation Method for WRF Model: 1 - Nearest Neighbor, 2 - Bi-Linear
@@ -67,12 +68,12 @@ setenv UPDATE_SITES T
 # it is the most time consuming part of AMET and that step is bypassed.
 setenv MAX_TIMES_SITE_CHECK 1
 
-# Automatic BSRN and SURFRAD Obs FTP Option. BSRN requires log/pass to access the FTP server.
-# SURFRAD is anonymous with user's work email for their tracking statistics.
+# Automatic BSRN, SOLRAD and SURFRAD Obs FTP Option. BSRN requires log/pass to access the FTP server.
+# SURFRAD/SOLRAD are anonymous with user's work email for their tracking statistics.
 # Also, users must have MADIS directory structure in place and MADISBASE pointing to that directory.
 # Current BSRN server is defined below. Note: only observation within the domain are downloaded.
-# Current NOAA SurfRad server defined in the case of srad option.
-# Both observation dataset are downloaded into MADISBASE/bsrn directory for consolidation.
+# Current NOAA SurfRad and SOLRAD server defined in the case of srad or solrad option.
+# All observation dataset are downloaded into MADISBASE/bsrn directory for consolidation.
 setenv AUTOFTP T
 
 if (${RADIATION_DSET} == "bsrn")  then
@@ -83,6 +84,12 @@ endif
 
 if (${RADIATION_DSET} == "srad")  then
   setenv RAD_SERVER https://gml.noaa.gov/aftp/data/radiation/surfrad
+  setenv RAD_LOGIN  anonymous
+  setenv RAD_PASS   lizadams@email.unc.edu 
+endif
+
+if (${RADIATION_DSET} == "solrad")  then
+  setenv RAD_SERVER https://gml.noaa.gov/aftp/data/radiation/solrad
   setenv RAD_LOGIN  anonymous
   setenv RAD_PASS   lizadams@email.unc.edu
 endif

--- a/scripts_db/metExample_ufs/matching_radiation.csh
+++ b/scripts_db/metExample_ufs/matching_radiation.csh
@@ -11,9 +11,9 @@ setenv AMET_DATABASE amet
 setenv MYSQL_SERVER  localhost
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
 
-# Root directory of BSRN/SURFRAD obs (same as MADIS). Note that this directory should
+# Root directory of BSRN/SURFRAD/SOLRAD obs (same as MADIS). Note that this directory should
 # contain a subdirectory "bsrn" where this radiation obs dataset (unzipped)
-# BSRN/SURFRAD directory configuration: $MADISBASE/bsrn 
+# BSRN/SURFRAD/SOLRAD directory configuration: $MADISBASE/bsrn 
 setenv MADISBASE $AMETBASE/obs/MET
 
 # A unique AMETPROJECT name for the simulation to evaluated. 
@@ -31,11 +31,12 @@ setenv FORECAST T
 # location below. A wildcard (*) is added in the script to get list of outputs.
 setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/aqm.t12z.phy
 
-# Radiation dataset to match with MPAS, WRF or MCIP -- Only shortwave radiation enabled
-# Options: "bsrn" or "srad"
+# Radiation dataset to match with MPAS, WRF, UFS or MCIP -- Only shortwave radiation enabled
+# Options: "bsrn", "srad" or "solrad"
 # BSRN is a global dataset with a lantency of months
-# SURFRAD is the US-based only SURFRAD Network that is real-time
-# Note: both datasets are downloaded into the $MADISBASE/bsrn directory (different naming)
+# SURFRAD is the US-based only network that is real-time
+# SOLRAD  is the US-based only network that is real-time
+# Note: All datasets are downloaded into the $MADISBASE/bsrn directory (different naming)
 setenv RADIATION_DSET srad 
 
 # Interpolation Method for WRF Model: 1 - Nearest Neighbor, 2 - Bi-Linear
@@ -67,12 +68,12 @@ setenv UPDATE_SITES T
 # it is the most time consuming part of AMET and that step is bypassed.
 setenv MAX_TIMES_SITE_CHECK 1
 
-# Automatic BSRN and SURFRAD Obs FTP Option. BSRN requires log/pass to access the FTP server.
-# SURFRAD is anonymous with user's work email for their tracking statistics.
+# Automatic BSRN, SOLRAD and SURFRAD Obs FTP Option. BSRN requires log/pass to access the FTP server.
+# SURFRAD/SOLRAD are anonymous with user's work email for their tracking statistics.
 # Also, users must have MADIS directory structure in place and MADISBASE pointing to that directory.
 # Current BSRN server is defined below. Note: only observation within the domain are downloaded.
-# Current NOAA SurfRad server defined in the case of srad option.
-# Both observation dataset are downloaded into MADISBASE/bsrn directory for consolidation.
+# Current NOAA SurfRad and SOLRAD server defined in the case of srad or solrad option.
+# All observation dataset are downloaded into MADISBASE/bsrn directory for consolidation.
 setenv AUTOFTP T
 
 if (${RADIATION_DSET} == "bsrn")  then
@@ -85,6 +86,12 @@ if (${RADIATION_DSET} == "srad")  then
   setenv RAD_SERVER https://gml.noaa.gov/aftp/data/radiation/surfrad
   setenv RAD_LOGIN  anonymous
   setenv RAD_PASS   lizadams@email.unc.edu 
+endif
+
+if (${RADIATION_DSET} == "solrad")  then
+  setenv RAD_SERVER https://gml.noaa.gov/aftp/data/radiation/solrad
+  setenv RAD_LOGIN  anonymous
+  setenv RAD_PASS   lizadams@email.unc.edu
 endif
 
 # Write hourly site insert statements and redirect statement to screen or logfile

--- a/scripts_db/metExample_wrf/matching_radiation.csh
+++ b/scripts_db/metExample_wrf/matching_radiation.csh
@@ -11,9 +11,9 @@ setenv AMET_DATABASE amet
 setenv MYSQL_SERVER  localhost
 setenv MYSQL_CONFIG  $AMETBASE/configure/amet-config.R
 
-# Root directory of BSRN/SURFRAD obs (same as MADIS). Note that this directory should
+# Root directory of BSRN/SURFRAD/SOLRAD obs (same as MADIS). Note that this directory should
 # contain a subdirectory "bsrn" where this radiation obs dataset (unzipped)
-# BSRN/SURFRAD directory configuration: $MADISBASE/bsrn 
+# BSRN/SURFRAD/SOLRAD directory configuration: $MADISBASE/bsrn 
 setenv MADISBASE $AMETBASE/obs/MET
 
 # A unique AMETPROJECT name for the simulation to evaluated. 
@@ -31,11 +31,12 @@ setenv FORECAST F
 # location below. A wildcard (*) is added in the script to get list of outputs.
 setenv METOUTPUT $AMETBASE/model_data/MET/$AMET_PROJECT/wrfout_subset
 
-# Radiation dataset to match with MPAS, WRF or MCIP -- Only shortwave radiation enabled
-# Options: "bsrn" or "srad"
+# Radiation dataset to match with MPAS, WRF, UFS or MCIP -- Only shortwave radiation enabled
+# Options: "bsrn", "srad" or "solrad"
 # BSRN is a global dataset with a lantency of months
-# SURFRAD is the US-based only SURFRAD Network that is real-time
-# Note: both datasets are downloaded into the $MADISBASE/bsrn directory (different naming)
+# SURFRAD is the US-based only network that is real-time
+# SOLRAD  is the US-based only network that is real-time
+# Note: All datasets are downloaded into the $MADISBASE/bsrn directory (different naming)
 setenv RADIATION_DSET bsrn 
 
 # Interpolation Method for WRF Model: 1 - Nearest Neighbor, 2 - Bi-Linear
@@ -67,12 +68,12 @@ setenv UPDATE_SITES T
 # it is the most time consuming part of AMET and that step is bypassed.
 setenv MAX_TIMES_SITE_CHECK 1
 
-# Automatic BSRN and SURFRAD Obs FTP Option. BSRN requires log/pass to access the FTP server.
-# SURFRAD is anonymous with user's work email for their tracking statistics.
+# Automatic BSRN, SOLRAD and SURFRAD Obs FTP Option. BSRN requires log/pass to access the FTP server.
+# SURFRAD/SOLRAD are anonymous with user's work email for their tracking statistics.
 # Also, users must have MADIS directory structure in place and MADISBASE pointing to that directory.
 # Current BSRN server is defined below. Note: only observation within the domain are downloaded.
-# Current NOAA SurfRad server defined in the case of srad option.
-# Both observation dataset are downloaded into MADISBASE/bsrn directory for consolidation.
+# Current NOAA SurfRad and SOLRAD server defined in the case of srad or solrad option.
+# All observation dataset are downloaded into MADISBASE/bsrn directory for consolidation.
 setenv AUTOFTP T
 
 if (${RADIATION_DSET} == "bsrn")  then
@@ -85,6 +86,12 @@ if (${RADIATION_DSET} == "srad")  then
   setenv RAD_SERVER https://gml.noaa.gov/aftp/data/radiation/surfrad
   setenv RAD_LOGIN  anonymous
   setenv RAD_PASS   lizadams@email.unc.edu 
+endif
+
+if (${RADIATION_DSET} == "solrad")  then
+  setenv RAD_SERVER https://gml.noaa.gov/aftp/data/radiation/solrad
+  setenv RAD_LOGIN  anonymous
+  setenv RAD_PASS   lizadams@email.unc.edu
 endif
 
 # Write hourly site insert statements and redirect statement to screen or logfile


### PR DESCRIPTION
Update solar radiation analysis in AMET to use NOAA SOLRAD dataset. This requires an update to the matching script, observation reading script and analysis script. Also updated were template files that have wording for the SOLRAD option and NOAA's archive location. 