### PR TITLE
Update AMET Upper-air scripts for various bugs

### DIFF
--- a/R_db_code/MET_observation.read.R
+++ b/R_db_code/MET_observation.read.R
@@ -389,10 +389,15 @@
     #       Native levels will be put in database for plotting.
     #       Mandantory levels will be matched with model for statistics.
     prest <- ncvar_get(f2, varid="prSigT")
-    presw <- ncvar_get(f2, varid="prSigW")
     presm <- ncvar_get(f2, varid="prMan")
     ghgtm <- ncvar_get(f2, varid="htMan")
     ghgts <- ncvar_get(f2, varid="htSigW")
+    if(ncdf_vars_exist(madis_file,"prSigW")) {
+      presw <- ncvar_get(f2, varid="prSigW")
+    } else {
+      writeLines("** QAWARNING ** Significant level wrt W-by-P not available. Not used. Disregard.")
+      presw <- 1
+    }
 
     mlevs <- dim(presm)[1]
     tlevs <- dim(prest)[1]

--- a/scripts_analysis/metExample_mcip/input_files/raob.static.input
+++ b/scripts_analysis/metExample_mcip/input_files/raob.static.input
@@ -48,7 +48,7 @@
 #########################################################################
  if(!exists("extra") )  { extra <- ""  }
  extra <- trimws(extra)
- if(extra!="" & (statid=="ALL" || TSERIESM)) {
+ if(extra!="" & (statid[1]=="ALL" || TSERIESM)) {
   extrall  <-paste(extrall,extra)
  }
 #########################################################################

--- a/scripts_analysis/metExample_mcip/run_raob.csh
+++ b/scripts_analysis/metExample_mcip/run_raob.csh
@@ -139,11 +139,11 @@
     echo "Single time native profile plots of RAOB and model soundings = .True."
 
     set envstr="${AMET_YY}"
-    set split_y = ($envstr:as/ / /)
+    set split_y = ($envstr:as/,/ /)
     set envstr="${AMET_MM}"
-    set split_m = ($envstr:as/ / /)
+    set split_m = ($envstr:as/,/ /)
     set envstr="${AMET_DD}"
-    set split_d = ($envstr:as/ / /)
+    set split_d = ($envstr:as/,/ /)
     set begday=${split_y[1]}${split_m[1]}${split_d[1]}
     set endday=${split_y[2]}${split_m[2]}${split_d[2]}
 

--- a/scripts_analysis/metExample_mpas/input_files/raob.static.input
+++ b/scripts_analysis/metExample_mpas/input_files/raob.static.input
@@ -48,7 +48,7 @@
 #########################################################################
  if(!exists("extra") )  { extra <- ""  }
  extra <- trimws(extra)
- if(extra!="" & (statid=="ALL" || TSERIESM)) {
+ if(extra!="" & (statid[1]=="ALL" || TSERIESM)) {
   extrall  <-paste(extrall,extra)
  }
 #########################################################################

--- a/scripts_analysis/metExample_mpas/run_raob.csh
+++ b/scripts_analysis/metExample_mpas/run_raob.csh
@@ -141,11 +141,11 @@
     echo "Single time native profile plots of RAOB and model soundings = .True."
 
     set envstr="${AMET_YY}"
-    set split_y = ($envstr:as/ / /)
+    set split_y = ($envstr:as/,/ /)
     set envstr="${AMET_MM}"
-    set split_m = ($envstr:as/ / /)
+    set split_m = ($envstr:as/,/ /)
     set envstr="${AMET_DD}"
-    set split_d = ($envstr:as/ / /)
+    set split_d = ($envstr:as/,/ /)
     set begday=${split_y[1]}${split_m[1]}${split_d[1]}
     set endday=${split_y[2]}${split_m[2]}${split_d[2]}
 

--- a/scripts_analysis/metExample_ufs/input_files/raob.static.input
+++ b/scripts_analysis/metExample_ufs/input_files/raob.static.input
@@ -48,7 +48,7 @@
 #########################################################################
  if(!exists("extra") )  { extra <- ""  }
  extra <- trimws(extra)
- if(extra!="" & (statid=="ALL" || TSERIESM)) {
+ if(extra!="" & (statid[1]=="ALL" || TSERIESM)) {
   extrall  <-paste(extrall,extra)
  }
 #########################################################################

--- a/scripts_analysis/metExample_ufs/run_raob.csh
+++ b/scripts_analysis/metExample_ufs/run_raob.csh
@@ -139,11 +139,11 @@
     echo "Single time native profile plots of RAOB and model soundings = .True."
 
     set envstr="${AMET_YY}"
-    set split_y = ($envstr:as/ / /)
+    set split_y = ($envstr:as/,/ /)
     set envstr="${AMET_MM}"
-    set split_m = ($envstr:as/ / /)
+    set split_m = ($envstr:as/,/ /)
     set envstr="${AMET_DD}"
-    set split_d = ($envstr:as/ / /)
+    set split_d = ($envstr:as/,/ /)
     set begday=${split_y[1]}${split_m[1]}${split_d[1]}
     set endday=${split_y[2]}${split_m[2]}${split_d[2]}
 

--- a/scripts_analysis/metExample_wrf/input_files/raob.static.input
+++ b/scripts_analysis/metExample_wrf/input_files/raob.static.input
@@ -48,7 +48,7 @@
 #########################################################################
  if(!exists("extra") )  { extra <- ""  }
  extra <- trimws(extra)
- if(extra!="" & (statid=="ALL" || TSERIESM)) {
+ if(extra!="" & (statid[1]=="ALL" || TSERIESM)) {
   extrall  <-paste(extrall,extra)
  }
 #########################################################################

--- a/scripts_analysis/metExample_wrf/run_raob.csh
+++ b/scripts_analysis/metExample_wrf/run_raob.csh
@@ -139,11 +139,11 @@
     echo "Single time native profile plots of RAOB and model soundings = .True."
 
     set envstr="${AMET_YY}"
-    set split_y = ($envstr:as/ / /)
+    set split_y = ($envstr:as/,/ /)
     set envstr="${AMET_MM}"
-    set split_m = ($envstr:as/ / /)
+    set split_m = ($envstr:as/,/ /)
     set envstr="${AMET_DD}"
-    set split_d = ($envstr:as/ / /)
+    set split_d = ($envstr:as/,/ /)
     set begday=${split_y[1]}${split_m[1]}${split_d[1]}
     set endday=${split_y[2]}${split_m[2]}${split_d[2]}
 


### PR DESCRIPTION
This update fixes a few problems encountered when users moved to Red Hat 8 systems where a system command does not execute as older systems. 

Also updates is a fix for older MADIS file pre-2005 where a specific variable was not in the old files. But this variable is not important currently. It was in the code for potential future updates. We did a comprehensive fix by checking to see if the variable is present and addressing the case if present or missing.

Third update is a fix for the raob analysis when a array of sites is provided.