### PR TITLE
Fix kelly plots for Met analysis

### DIFF
--- a/scripts_analysis/metExample_wrf/run_kellyplot_region_plotly.csh
+++ b/scripts_analysis/metExample_wrf/run_kellyplot_region_plotly.csh
@@ -63,7 +63,7 @@
   ### Species to Plot ###
   ### Acceptable Species Names: T, WVMR, SRAD, Wind_Speed, PCP1H, PSFC
 
-  setenv AMET_AQSPECIES	T 
+  setenv AMET_METSPECIES	T 
 
   ### Observation Network to plot
   ### Set to 'T' to process that nework

--- a/scripts_analysis/metExample_wrf/run_kellyplot_season_plotly.csh
+++ b/scripts_analysis/metExample_wrf/run_kellyplot_season_plotly.csh
@@ -63,7 +63,7 @@
   ### Species to Plot ###
   ### Acceptable Species Names: T, WVMR, SRAD, Wind_Speed, PCP1H, PSFC
 
-  setenv AMET_AQSPECIES	T 
+  setenv AMET_METSPECIES	T 
 
   ### Observation Network to plot
   ### Set to 'T' to process that nework


### PR DESCRIPTION
Renamed AMET_AQSPECIES to AMET_METSPECIES in the kelly plots. 

	modified:   run_kellyplot_region_plotly.csh
	modified:   run_kellyplot_season_plotly.csh